### PR TITLE
DE244356 - Put selected channels to X_OTP_CHANNEL header for the API …

### DIFF
--- a/MAG/src/main/java/com/ca/mas/core/policy/OtpAssertion.java
+++ b/MAG/src/main/java/com/ca/mas/core/policy/OtpAssertion.java
@@ -47,7 +47,7 @@ class OtpAssertion implements MssoAssertion {
             }
             String selectedChannels = extra.getString(OtpConstants.X_OTP_CHANNEL);
             if (selectedChannels != null) {
-                request.getRequest().addHeader(OtpConstants.X_OTP_CHANNEL, otp);
+                request.getRequest().addHeader(OtpConstants.X_OTP_CHANNEL, selectedChannels);
             }
         }
     }


### PR DESCRIPTION
Fix for defect: After failing to correctly enter OTP that was sent via SMS, the second one will be sent to email