### PR TITLE
Us97380307676 mas lock required encryption provider

### DIFF
--- a/mag/src/main/java/com/ca/mas/core/security/DefaultEncryptionProvider.java
+++ b/mag/src/main/java/com/ca/mas/core/security/DefaultEncryptionProvider.java
@@ -42,7 +42,7 @@ public class DefaultEncryptionProvider implements EncryptionProvider {
     private static final int IV_LENGTH = 12;
 
     public DefaultEncryptionProvider(@NonNull Context ctx) {
-        this(ctx, new SharedPreferencesKeyStorageProvider(ctx));
+        this(ctx, new KeyStorageScreenLockCanChange(ctx));
     }
 
     public DefaultEncryptionProvider(Context ctx, KeyStorageProvider keyStorageProvider) {

--- a/mag/src/main/java/com/ca/mas/core/security/DefaultKeySymmetricManager.java
+++ b/mag/src/main/java/com/ca/mas/core/security/DefaultKeySymmetricManager.java
@@ -52,6 +52,7 @@ public class DefaultKeySymmetricManager implements KeySymmetricManager {
     private boolean mInMemory = true;
     private boolean mUserAuthenticationRequired = false;
     private int mUserAuthenticationValiditySeconds = -1;
+    private boolean mNougat_invalidatedByBiometricEnrollment = false;
 
 
     /**
@@ -61,20 +62,62 @@ public class DefaultKeySymmetricManager implements KeySymmetricManager {
     }
 
     /**
-     * Constructor, allows for full selection of key properties
+     * Constructor, allows for full selection of key properties.  This can
+     *   only be used for Symmetric (AES) Keys for Android.M+.
+     *
+     * “The Android Keystore system lets you store cryptographic keys in a
+     * container to make it more difficult to extract from the device.
+     * Once keys are in the keystore, they can be used for cryptographic
+     * operations with the key material remaining non-exportable”.
+     * This means that the key can't be extracted from the keystore, and
+     * note that keys can only be shared between applications with
+     * the same signing key and shared user id.
+     * Therefore, it is not necessary to protect private keys stored
+     * in the AndroidKeyStore with a screen lock in the same way
+     * encryption was required for Pre-M.
+     * <p>
+     * The key protection parameters for AndroidKeyStore AES keys
+     * userAuthenticationValidityDurationSeconds,
+     * and nougat_setInvalidatedByBiometricEnrollment are linked,
+     * below are the combinations:
+     * <p>
+     * 1) userAuthenticationRequired(false) – the keys
+     *      are still protected from export but can be used whenever needed.
+     * 2) userAuthenticationRequired(true) and
+     *      userAuthenticationValidityDurationSeconds( > 0 ) –
+     *      the key can only be used if the pin has been entered within the given
+     *      number of seconds.  On some devices, when a fingerprint is added
+     *      the key is invalidated.
+     * 3) userAuthenticationRequired(true) and
+     *      userAuthenticationValidityDurationSeconds(zero) –
+     *      works only with fingerprint+pin/swipe/pattern, and requires that
+     *      the fingerprint is entered every time a key is used.  This requires
+     *      an added layer to prompt the user to swipe their fingerprint.
+     * 4) Android N+: nougat_setInvalidatedByBiometricEnrollment(true/false)
+     *      changes the behavior in #2 – either the key will or won’t be
+     *      invalided when the user adds an or another fingerprint.
      *
      * @param algorithm AES or other Symmetric Key algorithm
      * @param keyLength default is 256
-     * @param inMemory for Android.M+ the key will be created outside the AndroidKeyStore and then stored
-     *                    inside.  The in-memory copy can be used without user authentication until the
-     *                    app is closed, dereferenced, or variable is destroyed.
-     * @param userAuthenticationRequired for Android.M+ require screen lock.  Note, if inMemory is true,
-     *                    this applies only to versions extracted from the AndroidKeyStore.
-     * @param userAuthenticationValiditySeconds sets the duration for which this key is authorized
-     *                    to be used after the user is successfully authenticated.
+     * @param inMemory the key will be created outside the AndroidKeyStore and then stored
+     *                      inside.  The in-memory copy can be used without user authentication until the
+     *                      app is closed, dereferenced, or variable is destroyed.
+     * @param userAuthenticationRequired
+     *                      true/false, requires a lock screen in order to use the key.
+     * @param userAuthenticationValidityDurationSeconds
+     *                      if user authentication is required, this specifies the number of seconds after
+     *                      unlocking the screen wherein key is still usable.  If this value is zero or negative, a
+     *                      fingerprint is required for every use.  Can be set to 100,000, which would only
+     *                      require a screen unlock within the last day or so.
+     * @param nougat_invalidatedByBiometricEnrollment
+     *                      true/false: if setUserAuthenticationRequired true, some Android M devices may disable
+     *                      a key if a fingerprint is added.  Setting this value to true ensures
+     *                      the key is usable even if a fingerprint is added.
      */
-    public DefaultKeySymmetricManager(String algorithm, int keyLength,
-                       boolean inMemory, boolean userAuthenticationRequired, int userAuthenticationValiditySeconds)
+    public DefaultKeySymmetricManager(String algorithm, int keyLength, boolean inMemory,
+                       boolean userAuthenticationRequired,
+                       int userAuthenticationValiditySeconds,
+                       boolean nougat_invalidatedByBiometricEnrollment)
     {
 
         if (keyLength < 0) {
@@ -90,6 +133,7 @@ public class DefaultKeySymmetricManager implements KeySymmetricManager {
         mInMemory = inMemory;
         mUserAuthenticationRequired = userAuthenticationRequired;
         mUserAuthenticationValiditySeconds = userAuthenticationValiditySeconds;
+        mNougat_invalidatedByBiometricEnrollment = nougat_invalidatedByBiometricEnrollment;
     }
 
 
@@ -165,8 +209,11 @@ public class DefaultKeySymmetricManager implements KeySymmetricManager {
                     .setRandomizedEncryptionRequired(true)
                     .setUserAuthenticationRequired(mUserAuthenticationRequired);
 
-            if (mUserAuthenticationRequired && mUserAuthenticationValiditySeconds > 0)
+            if (mUserAuthenticationRequired)
                 builder.setUserAuthenticationValidityDurationSeconds(mUserAuthenticationValiditySeconds);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+                builder.setInvalidatedByBiometricEnrollment(mNougat_invalidatedByBiometricEnrollment);
 
             KeyGenParameterSpec keyGenSpec = builder.build();
             keyGenerator.init(keyGenSpec);

--- a/mag/src/main/java/com/ca/mas/core/security/EncryptionProviderScreenLockCanChange.java
+++ b/mag/src/main/java/com/ca/mas/core/security/EncryptionProviderScreenLockCanChange.java
@@ -32,7 +32,7 @@ import javax.security.auth.Destroyable;
 import static com.ca.mas.core.MAG.DEBUG;
 import static com.ca.mas.core.MAG.TAG;
 
-public class DefaultEncryptionProvider implements EncryptionProvider {
+public class EncryptionProviderScreenLockCanChange implements EncryptionProvider {
     private KeyStorageProvider ksp;
     private static final String KEY_ALIAS = "secret";
     private static final String ALGORITHM = "AES";
@@ -41,11 +41,11 @@ public class DefaultEncryptionProvider implements EncryptionProvider {
     private static final String HMAC_SHA256 = "HmacSHA256";
     private static final int IV_LENGTH = 12;
 
-    public DefaultEncryptionProvider(@NonNull Context ctx) {
+    public EncryptionProviderScreenLockCanChange(@NonNull Context ctx) {
         this(ctx, new KeyStorageScreenLockCanChange(ctx));
     }
 
-    public DefaultEncryptionProvider(Context ctx, KeyStorageProvider keyStorageProvider) {
+    public EncryptionProviderScreenLockCanChange(Context ctx, KeyStorageProvider keyStorageProvider) {
         ksp = keyStorageProvider;
     }
 

--- a/mag/src/main/java/com/ca/mas/core/security/EncryptionProviderScreenLockCanChange.java
+++ b/mag/src/main/java/com/ca/mas/core/security/EncryptionProviderScreenLockCanChange.java
@@ -42,7 +42,7 @@ public class DefaultEncryptionProvider implements EncryptionProvider {
     private static final int IV_LENGTH = 12;
 
     public DefaultEncryptionProvider(@NonNull Context ctx) {
-        this(ctx, new SharedPreferencesKeyStorageProvider(ctx));
+        this(ctx, new KeyStorageScreenLockCanChange(ctx));
     }
 
     public DefaultEncryptionProvider(Context ctx, KeyStorageProvider keyStorageProvider) {

--- a/mag/src/main/java/com/ca/mas/core/security/KeyStorageScreenLockCanChange.java
+++ b/mag/src/main/java/com/ca/mas/core/security/KeyStorageScreenLockCanChange.java
@@ -62,7 +62,7 @@ class KeyStorageScreenLockCanChange extends SharedPreferencesKeyStorageProvider 
 
         // Symmetric Key Manager creates symmetric keys,
         //   stored inside AndroidKeyStore for Android.M+
-        keyMgr = new DefaultKeySymmetricManager("AES", 256, false, true, 100000, false);
+        keyMgr = new DefaultKeySymmetricManager("AES", 256, false, false, 100000, false);
     }
 
 

--- a/mag/src/main/java/com/ca/mas/core/security/KeyStorageScreenLockCanChange.java
+++ b/mag/src/main/java/com/ca/mas/core/security/KeyStorageScreenLockCanChange.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2016 CA. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ */
+
+package com.ca.mas.core.security;
+
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.ca.mas.core.util.KeyUtils;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.UnrecoverableKeyException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+
+import static com.ca.mas.core.MAG.DEBUG;
+import static com.ca.mas.core.MAG.TAG;
+
+/**
+ * This class supports key storage.  It will require a screen lock,
+ *   but the screen lock can change.  For Android pre-N, this is 
+ *   managed entirely by checking KeyguardManager.isDeviceSecure()
+ *   to determine if there is still a screen lock.  If the screen
+ *   lock, pin/swipe/password, is removed entirely, the keys are
+ *   deleted.  For Android.N, the keys are also protected inside
+ *   the AndroidKeyStore requiring a screen lock.
+ */
+
+class KeyStorageScreenLockCanChange extends SharedPreferencesKeyStorageProvider {
+
+    public static final String PREFS_NAME = "SECRET_PREFS";
+    private SharedPreferences sharedpreferences;
+
+    /**
+     * Constructor to KeyStorageProvider
+     *
+     * @param ctx requires context of the calling application
+     */
+    public KeyStorageScreenLockCanChange(@NonNull Context ctx) {
+        super(ctx);
+
+        // Symmetric Key Manager creates symmetric keys,
+        //   stored inside AndroidKeyStore for Android.M+
+        keyMgr = new DefaultKeySymmetricManager("AES", 256, false, true, 100000, false);
+    }
+
+
+    /**
+     * Determine if there is a screen lock
+     */
+    protected boolean deviceHasScreenLock()
+    {
+        try {
+            KeyguardManager km = (KeyguardManager) context.getSystemService(Context.KEYGUARD_SERVICE);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if ( km.isDeviceSecure() )
+                    return true;
+                else
+                    return false;
+            } else {
+                if ( km.isKeyguardSecure() )
+                    return true;
+                else
+                    return false;
+            }
+        } catch (Exception x) {
+            Log.e(TAG, "Exception determining if screen has a lock (pin/swipe/password), will be assuming it does not", x);
+            return false;
+        }
+    }
+
+
+    /**
+     * Retrieve the SecretKey from Storage
+     *
+     * @param alias : The alias to find the Key
+     * @return The SecretKey
+     */
+    @Override
+    public SecretKey getKey(String alias) {
+
+        // if there is no screen lock, then delete the key and return nothing!!!
+        if (! deviceHasScreenLock()) {
+            Log.w(TAG, "KeyStorageScreenLockCanChange getKey there is no screen lock (pin/swipe/password), so the key will be deleted");
+            removeKey(alias);
+            throw new RuntimeException("KeyStorageScreenLockCanChange getKey there is no screen lock (pin/swipe/password), so the encryption key has been deleted");
+        }
+
+        // For Android.M+, if this key was created we'll find it here
+        SecretKey secretKey = keyMgr.retrieveKey(alias);
+
+        if (secretKey == null) {
+
+            // check if the key is present locally
+            byte encryptedSecretKey[] = getEncryptedSecretKey(alias);
+            if (encryptedSecretKey != null) {
+                try {
+                    secretKey = decryptSecretKey(encryptedSecretKey);
+                } catch (Exception unableToDecrypt) {
+                    if (DEBUG)
+                        Log.e(TAG, "Error while decrypting SecretKey, deleting it", unableToDecrypt);
+
+                    deleteSecretKeyLocally(alias);
+                    encryptedSecretKey = null;
+                }
+            }
+
+            // if still no key, generate one
+            if (secretKey == null) {
+                secretKey = keyMgr.generateKey(alias);
+
+                // if this is Pre- Android.M, we need to store it locally
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                    encryptedSecretKey = encryptSecretKey(secretKey);
+                    storeSecretKeyLocally(alias, encryptedSecretKey);
+                }
+            } else {
+                // if this is Android.M+, check if the operating system was upgraded
+                //   and we can now store the SecretKey in the AndroidKeyStore
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    keyMgr.storeKey(alias, secretKey);
+                    deleteSecretKeyLocally(alias);
+                }
+            }
+        }
+
+        return secretKey;
+    }
+
+
+    /**
+     * This method encrypts a SecretKey using an RSA key.
+     * This is intended for Pre-Android.M, where the
+     * SecretKey cannot be stored in the AndroidKeyStore
+     *
+     * @param secretKey SecretKey to encrypt
+     */
+    protected byte[] encryptSecretKey(SecretKey secretKey) {
+        try {
+            PublicKey publicKey = KeyUtils.getRsaPublicKey(ASYM_KEY_ALIAS);
+            if (publicKey == null) {
+                KeyUtils.generateRsaPrivateKey(context, 2048,
+                        ASYM_KEY_ALIAS, String.format("CN=%s, OU=%s", ASYM_KEY_ALIAS, "com.ca"),
+                        false, false, -1, false);
+                publicKey = KeyUtils.getRsaPublicKey(ASYM_KEY_ALIAS);
+            }
+
+            Cipher cipher = Cipher.getInstance(RSA_ECB_PKCS1_PADDING);
+            cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+            return cipher.doFinal(secretKey.getEncoded());
+
+        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException
+                | NoSuchPaddingException | NoSuchAlgorithmException | NoSuchProviderException
+                | IOException | InvalidParameterException | KeyStoreException
+                | InvalidAlgorithmParameterException | CertificateException
+                | UnrecoverableKeyException e) {
+            if (DEBUG) Log.e(TAG, "Error while encrypting SecretKey", e);
+            throw new RuntimeException("Error while encrypting SecretKey", e);
+        }
+    }
+
+
+
+}

--- a/mag/src/main/java/com/ca/mas/core/security/KeyStoreKeyStorageProvider.java
+++ b/mag/src/main/java/com/ca/mas/core/security/KeyStoreKeyStorageProvider.java
@@ -51,7 +51,7 @@ public abstract class KeyStoreKeyStorageProvider implements KeyStorageProvider {
     protected static final String ASYM_KEY_ALIAS = "ASYM_KEY";
     public static final String RSA_ECB_PKCS1_PADDING = "RSA/ECB/PKCS1PADDING";
 
-    private Context context;
+    protected Context context;
 
     /**
      * Default constructor generates a DefaultKeySymmetricManager
@@ -63,7 +63,7 @@ public abstract class KeyStoreKeyStorageProvider implements KeyStorageProvider {
 
         // Symmetric Key Manager creates symmetric keys,
         //   stored inside AndroidKeyStore for Android.M+
-        keyMgr = new DefaultKeySymmetricManager("AES", 256, true, false, -1);
+        keyMgr = new DefaultKeySymmetricManager("AES", 256, true, false, -1, false);
 
     }
 

--- a/mag/src/main/java/com/ca/mas/core/security/LockableKeyStorageProvider.java
+++ b/mag/src/main/java/com/ca/mas/core/security/LockableKeyStorageProvider.java
@@ -40,7 +40,7 @@ public class LockableKeyStorageProvider implements KeyStorageProvider {
     {
         // Symmetric keys will be generated in memory then stored in AndroidKeyStore
         if (keyMgr == null)
-            keyMgr = new DefaultKeySymmetricManager("AES", 256, true, true, 10);
+            keyMgr = new DefaultKeySymmetricManager("AES", 256, true, true, 10, false);
 
         SecretKey secretKey = secretKeys.get(alias);
         if (secretKey == null) {
@@ -64,7 +64,7 @@ public class LockableKeyStorageProvider implements KeyStorageProvider {
     public boolean removeKey(String alias)
     {
         if (keyMgr == null)
-            keyMgr = new DefaultKeySymmetricManager("AES", 256, true, true, 10);
+            keyMgr = new DefaultKeySymmetricManager("AES", 256, true, true, 10, false);
 
         secretKeys.remove(alias);
         keyMgr.deleteKey(alias);

--- a/mag/src/main/java/com/ca/mas/core/util/KeyUtils.java
+++ b/mag/src/main/java/com/ca/mas/core/util/KeyUtils.java
@@ -61,7 +61,7 @@ public class KeyUtils {
      * This will always create the key pair inside the AndroidKeyStore,
      * ensuring it is always protected.
      * <p>
-     * For Pre-M, lollipop_setEncryptionRequired requires that the user sets
+     * For Pre-M, lollipop_encryptionRequired requires that the user sets
      * a screen lock and that the keys will be encrypted at rest.
      * <p>
      * For M+:
@@ -100,10 +100,14 @@ public class KeyUtils {
      * @param context                                               needed for generating key pre-M
      * @param keysize                                               the key size in bits, eg 2048.
      * @param alias                                                 the keystore alias to use
-     * @param marshmallowUserAuthenticationRequired                true/false for Android-M+:
+     * @param dn                                                    the dn for the initial self-signed certificate
+     * @param lollipop_encryptionRequired                           true/false for pre-Android-M:
+     *                                                              requires that the user sets a screen lock and 
+     *                                                              that the keys will be encrypted at rest
+     * @param marshmallow_userAuthenticationRequired                true/false for Android-M+:
      *                                                              requires a lock screen in order to use the key.  If the validity duration
      *                                                              is equal to zero, a fingerprint validation is required for every use of the key.
-     * @param marshmallowUserAuthenticationValidityDurationSeconds # secs for Android-M+:
+     * @param marshmallow_userAuthenticationValidityDurationSeconds # secs for Android-M+:
      *                                                              if user authentication is required, this specifies the number of seconds after
      *                                                              unlocking the screen where key is still usable.  If this value is zero, a
      *                                                              fingerprint is required for every use.
@@ -111,15 +115,14 @@ public class KeyUtils {
      *                                                              if setUserAuthenticationRequired true, some Android M devices may disable
      *                                                              a key if a fingerprint is added.  Setting this value to true ensures
      *                                                              the key is usabl even if a fingerprint is added.
-     * @return a new RSA PrivateKey.
+     * @return a new RSA PrivateKey, created in and protected by the AndroidKeyStore.
+     *           The matching self-signed public certificate can only be deleted if the private key is deleted as well.
      * @throws RuntimeException if an RSA key pair of the requested size cannot be generated
-     * @oaram lollipop_setEncryptionRequired true/false for pre-Android-M:
-     * requires that the user sets a screen lock and that the keys will be encrypted at rest
      */
     public static PrivateKey generateRsaPrivateKey(Context context, int keysize,
                                                    String alias, String dn, boolean lollipop_encryptionRequired,
-                                                   boolean marshmallowUserAuthenticationRequired,
-                                                   int marshmallowUserAuthenticationValidityDurationSeconds,
+                                                   boolean marshmallow_userAuthenticationRequired,
+                                                   int marshmallow_userAuthenticationValidityDurationSeconds,
                                                    boolean nougat_invalidatedByBiometricEnrollment)
             throws java.security.InvalidAlgorithmParameterException, java.io.IOException,
             java.security.KeyStoreException, java.security.NoSuchAlgorithmException,
@@ -133,14 +136,14 @@ public class KeyUtils {
             // use KeyGenParameterSpec.Builder, new in Marshmallow
             //   and include nougat_invalidatedByBiometricEnrollment
             return generateRsaPrivateKey_AndroidN(keysize, alias, dn,
-                    marshmallowUserAuthenticationRequired,
-                    marshmallowUserAuthenticationValidityDurationSeconds,
+                    marshmallow_userAuthenticationRequired,
+                    marshmallow_userAuthenticationValidityDurationSeconds,
                     nougat_invalidatedByBiometricEnrollment);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             // use KeyGenParameterSpec.Builder, new in Marshmallow
             return generateRsaPrivateKey_AndroidM(keysize, alias, dn,
-                    marshmallowUserAuthenticationRequired,
-                    marshmallowUserAuthenticationValidityDurationSeconds);
+                    marshmallow_userAuthenticationRequired,
+                    marshmallow_userAuthenticationValidityDurationSeconds);
         } else {
             return generateRsaPrivateKey_AndroidL(context, keysize,
                     alias, dn, lollipop_encryptionRequired);
@@ -156,14 +159,16 @@ public class KeyUtils {
      *
      * @param context needed for generating key Android.M+
      * @param keysize the key size in bits, eg 2048.
-     * @param alias   the keystore alias to use
-     * @return a new RSA PrivateKey.
+     * @param alias the keystore alias to use
+     * @param dn the dn for the initial self-signed certificate
+     * @oaram encryptionRequired true/false for pre-Android-M:
+     *           requires that the user sets a screen lock and that the keys will be encrypted at rest
+     * @return a new RSA PrivateKey, created in and protected by the AndroidKeyStore.
+     *           The matching self-signed public certificate cannot be deleted.
      * @throws RuntimeException if an RSA key pair of the requested size cannot be generated
-     * @oaram lollipop_setEncryptionRequired true/false for pre-Android-M:
-     * requires that the user sets a screen lock and that the keys will be encrypted at rest
      */
     private static PrivateKey generateRsaPrivateKey_AndroidL(Context context, int keysize,
-                                                             String alias, String dn, boolean setEncryptionRequired)
+                                                             String alias, String dn, boolean encryptionRequired)
             throws java.security.InvalidAlgorithmParameterException, java.io.IOException,
             java.security.KeyStoreException, java.security.NoSuchAlgorithmException,
             java.security.NoSuchProviderException, java.security.cert.CertificateException,
@@ -179,7 +184,8 @@ public class KeyUtils {
         cal.add(Calendar.YEAR, 1);
         Date end = cal.getTime();
 
-        if (setEncryptionRequired) {
+        if (encryptionRequired) {
+
             kpg.initialize(new KeyPairGeneratorSpec.Builder(context)
                     .setAlias(alias)
                     .setAlgorithmParameterSpec(spec)
@@ -189,6 +195,7 @@ public class KeyUtils {
                     .setSubject(new X500Principal(dn))
                     .build());
         } else {
+
             kpg.initialize(new KeyPairGeneratorSpec.Builder(context)
                     .setAlias(alias)
                     .setAlgorithmParameterSpec(spec)
@@ -207,6 +214,7 @@ public class KeyUtils {
      *
      * @param keysize                                   the key size in bits, eg 2048.
      * @param alias                                     the alias against which to store the key against
+     * @param dn                                        the dn for the initial self-signed certificate
      * @param userAuthenticationRequired                true/false for Android-M+:
      *                                                  requires a lock screen in order to use the key.  If the validity duration
      *                                                  is equal to zero, a fingerprint validation is required for every use of the key.
@@ -214,8 +222,8 @@ public class KeyUtils {
      *                                                  if user authentication is required, this specifies the number of seconds after
      *                                                  unlocking the screen where key is still usable.  If this value is zero, a
      *                                                  fingerprint is required for every use.
-     * @return a new RSA keypair, created in and protected by the AndroidKeyStore, with an
-     * unusable self-signed certificate
+     * @return a new RSA PrivateKey, created in and protected by the AndroidKeyStore.
+     *           The matching self-signed public certificate cannot be deleted.
      */
     @TargetApi(Build.VERSION_CODES.M)
     private static PrivateKey generateRsaPrivateKey_AndroidM(int keysize,
@@ -262,6 +270,7 @@ public class KeyUtils {
      *
      * @param keysize                                   the key size in bits, eg 2048.
      * @param alias                                     the alias against which to store the key against
+     * @param dn                                        the dn for the initial self-signed certificate
      * @param userAuthenticationRequired                true/false for Android-M+:
      *                                                  requires a lock screen in order to use the key.  If the validity duration
      *                                                  is equal to zero, a fingerprint validation is required for every use of the key.
@@ -273,8 +282,8 @@ public class KeyUtils {
      *                                                  if setUserAuthenticationRequired true, some Android M devices may disable
      *                                                  a key if a fingerprint is added.  Setting this value to true ensures
      *                                                  the key is usabl even if a fingerprint is added.
-     * @return a new RSA keypair, created in and protected by the AndroidKeyStore, with an
-     * unusable self-signed certificate
+     * @return a new RSA PrivateKey, created in and protected by the AndroidKeyStore.
+     *           The matching self-signed public certificate cannot be deleted.
      */
     @TargetApi(Build.VERSION_CODES.N)
     private static PrivateKey generateRsaPrivateKey_AndroidN(int keysize,
@@ -318,10 +327,9 @@ public class KeyUtils {
 
     /**
      * Get the existing private key.
-     * Note: the initial self-signed public cert is typically not useful.
      *
      * @param alias the alias of the existing private key
-     * @return the Private Key object
+     * @return the Private Key 
      */
     public static PrivateKey getRsaPrivateKey(String alias)
             throws java.io.IOException, java.security.KeyStoreException,
@@ -334,10 +342,10 @@ public class KeyUtils {
 
 
     /**
-     * Get the existing public key.
-     * Note: the private key will be associated with the initial
-     * self-signed public certificate.  The PublicKey can be
-     * used in a Certificate Signing Request.
+     * Get the existing self-signed public key.
+     * Note: the private key will always be associated with the initial
+     *      self-signed public certificate.  The PublicKey can be
+     *      used in a Certificate Signing Request.
      *
      * @param alias the alias of the existing private key
      * @return the Private Key object
@@ -356,8 +364,8 @@ public class KeyUtils {
 
 
     /**
-     * Remove the existing public key.
-     * Note: the initial self-signed public cert is not usable.
+     * Remove the existing public and private keypair.  This will
+     *    not remove a certificate chain stored separately.
      *
      * @param alias the alias of the existing private key +
      *              self-signed public key
@@ -377,6 +385,12 @@ public class KeyUtils {
     /**
      * This will install or replace the existing certificate chain in the AndroidKeyStore.
      * The chain will be stored as "alias#".
+     * When private keys are generated, there is always a self-signed certificate
+     *    generated at the same time.  In other keystore types, this self-signed certificate
+     *    can be replaced by a CA-signed public cert.  For AndroidKeyStore, the self-signed
+     *    certificate cannot be replaced.  Therefore, any new certificate chain generated
+     *    for the original public key will always remain.  This will store the certificate
+     *    chain under a separate alias.
      *
      * @param aliasPrefix the alias prefix to use, will be appended with position number,
      *                    where position 0 in the array will be 1.
@@ -399,7 +413,9 @@ public class KeyUtils {
     }
 
     /**
-     * Clear any existing certificates in the public certificate chain.
+     * This will return the CA-signed certificate chain stored in the
+     *   AndroidKeyStore.  Note this is stored separately from the 
+     *   self-signed public certificate from any RSA keypair.
      *
      * @param aliasPrefix
      * @return
@@ -431,7 +447,9 @@ public class KeyUtils {
     }
 
     /**
-     * This will install or replace the existing certificate chain in the AndroidKeyStore.
+     * This will delete the existing certificate chain in the AndroidKeyStore.
+     *   It will not delete any RSA self-signed public certificate from a
+     *   generated KeyPair.
      * The chain will be stored as "alias#".
      *
      * @param aliasPrefix the alias prefix to use, will be appended with position number,
@@ -450,6 +468,9 @@ public class KeyUtils {
         }
     }
 
+    /**
+     *  Unused constructor
+     */
     private KeyUtils() {
     }
 }

--- a/mag/src/main/java/com/ca/mas/core/util/KeyUtils.java
+++ b/mag/src/main/java/com/ca/mas/core/util/KeyUtils.java
@@ -81,21 +81,21 @@ public class KeyUtils {
      * and nougat_setInvalidatedByBiometricEnrollment are linked,
      * below are the combinations:
      * <p>
-     * 1) Android M+: marshmallow_setUserAuthenticationRequired(false) – the keys
-     * are still protected from export but can be used whenever needed.
-     * 2) Android M+: marshmallow_setUserAuthenticationRequired(true) and
-     * marshmallow_setUserAuthenticationValidityDurationSeconds( > 0 ) –
-     * the key can only be used if the pin has been entered within the given
-     * number of seconds.  On some devices, when a fingerprint is added
-     * the key is invalidated.
-     * 3) Android M+: marshmallow_setUserAuthenticationRequired(true) and
-     * marshmallow_setUserAuthenticationValidityDurationSeconds(zero) –
-     * works only with fingerprint+pin/swipe/pattern, and requires that
-     * the fingerprint is entered every time a key is used.  This requires
-     * an added layer to prompt the user to swipe their fingerprint.
+     * 1) userAuthenticationRequired(false) – the keys
+     *      are still protected from export but can be used whenever needed.
+     * 2) userAuthenticationRequired(true) and
+     *      userAuthenticationValidityDurationSeconds( > 0 ) –
+     *      the key can only be used if the pin/fingerprint has been entered within the
+     *      given number of seconds.  On some devices, when a fingerprint is added
+     *      the key is invalidated.  At least one fingerprint must be registered.
+     * 3) userAuthenticationRequired(true) and
+     *      userAuthenticationValidityDurationSeconds(zero) –
+     *      works only with fingerprint+pin/swipe/pattern, and requires that
+     *      the fingerprint is entered every time a key is used.  This requires
+     *      an added layer to prompt the user to swipe their fingerprint.
      * 4) Android N+: nougat_setInvalidatedByBiometricEnrollment(true/false)
-     * changes the behavior in #2 – either the key will or won’t be
-     * invalided when the user adds an or another fingerprint.
+     *      changes the behavior in #2 – either the key will or won’t be
+     *      invalided when the user adds an or another fingerprint.
      *
      * @param context                                               needed for generating key pre-M
      * @param keysize                                               the key size in bits, eg 2048.
@@ -239,8 +239,7 @@ public class KeyUtils {
         Date now = cal.getTime();
         cal.add(Calendar.YEAR, 1);
         Date end = cal.getTime();
-        keyPairGenerator.initialize(
-                new KeyGenParameterSpec.Builder(alias,
+        KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(alias,
                         KeyProperties.PURPOSE_ENCRYPT + KeyProperties.PURPOSE_DECRYPT
                                 + KeyProperties.PURPOSE_SIGN + KeyProperties.PURPOSE_VERIFY)
                         .setKeySize(keysize)
@@ -248,7 +247,6 @@ public class KeyUtils {
                         .setCertificateSubject(new X500Principal("CN=msso"))
                         .setCertificateSerialNumber(BigInteger.valueOf(1))
                         .setUserAuthenticationRequired(userAuthenticationRequired)
-                        .setUserAuthenticationValidityDurationSeconds(userAuthenticationValidityDurationSeconds)
                         // In HttpUrlConnection, com.android.org.conscrypt.CryptoUpcalls.rawSignDigestWithPrivateKey
                         //   requires "NONEwithRSA", so we need to include DIGEST_NONE
                         //   therefore we can only setRandomizedEncruptionRequired to false
@@ -257,8 +255,11 @@ public class KeyUtils {
                         .setBlockModes(BLOCK_MODE_CBC, BLOCK_MODE_CTR, BLOCK_MODE_ECB, BLOCK_MODE_GCM)
                         .setDigests(DIGEST_NONE, DIGEST_MD5, DIGEST_SHA1, DIGEST_SHA256, DIGEST_SHA384, DIGEST_SHA512)
                         .setEncryptionPaddings(ENCRYPTION_PADDING_PKCS7, ENCRYPTION_PADDING_RSA_OAEP, ENCRYPTION_PADDING_RSA_PKCS1)
-                        .setSignaturePaddings(SIGNATURE_PADDING_RSA_PSS, SIGNATURE_PADDING_RSA_PKCS1)
-                        .build());
+                        .setSignaturePaddings(SIGNATURE_PADDING_RSA_PSS, SIGNATURE_PADDING_RSA_PKCS1);
+        if (userAuthenticationRequired)
+            builder.setUserAuthenticationValidityDurationSeconds(userAuthenticationValidityDurationSeconds);
+
+        keyPairGenerator.initialize(builder.build());
         return keyPairGenerator.generateKeyPair().getPrivate();
     }
 
@@ -300,8 +301,7 @@ public class KeyUtils {
         Date now = cal.getTime();
         cal.add(Calendar.YEAR, 1);
         Date end = cal.getTime();
-        keyPairGenerator.initialize(
-                new KeyGenParameterSpec.Builder(alias,
+        KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(alias,
                         KeyProperties.PURPOSE_ENCRYPT + KeyProperties.PURPOSE_DECRYPT
                                 + KeyProperties.PURPOSE_SIGN + KeyProperties.PURPOSE_VERIFY)
                         .setKeySize(keysize)
@@ -309,7 +309,6 @@ public class KeyUtils {
                         .setCertificateSubject(new X500Principal("CN=msso"))
                         .setCertificateSerialNumber(BigInteger.valueOf(1))
                         .setUserAuthenticationRequired(userAuthenticationRequired)
-                        .setUserAuthenticationValidityDurationSeconds(userAuthenticationValidityDurationSeconds)
                         .setInvalidatedByBiometricEnrollment(invalidatedByBiometricEnrollment)
                         // In HttpUrlConnection, com.android.org.conscrypt.CryptoUpcalls.rawSignDigestWithPrivateKey
                         //   requires "NONEwithRSA", so we need to include DIGEST_NONE
@@ -319,8 +318,11 @@ public class KeyUtils {
                         .setBlockModes(BLOCK_MODE_CBC, BLOCK_MODE_CTR, BLOCK_MODE_ECB, BLOCK_MODE_GCM)
                         .setDigests(DIGEST_NONE, DIGEST_MD5, DIGEST_SHA1, DIGEST_SHA256, DIGEST_SHA384, DIGEST_SHA512)
                         .setEncryptionPaddings(ENCRYPTION_PADDING_PKCS7, ENCRYPTION_PADDING_RSA_OAEP, ENCRYPTION_PADDING_RSA_PKCS1)
-                        .setSignaturePaddings(SIGNATURE_PADDING_RSA_PSS, SIGNATURE_PADDING_RSA_PKCS1)
-                        .build());
+                        .setSignaturePaddings(SIGNATURE_PADDING_RSA_PSS, SIGNATURE_PADDING_RSA_PKCS1);
+        if (userAuthenticationRequired)
+            builder.setUserAuthenticationValidityDurationSeconds(userAuthenticationValidityDurationSeconds);
+
+        keyPairGenerator.initialize(builder.build());
         return keyPairGenerator.generateKeyPair().getPrivate();
     }
 

--- a/mag/src/main/java/sun/security/x509/X500Name.java
+++ b/mag/src/main/java/sun/security/x509/X500Name.java
@@ -1420,7 +1420,7 @@ public class X500Name implements GeneralNameInterface, Principal {
      * Retrieve the Constructor and Field we need for reflective access
      * and make them accessible.
      */
-    /* SANDY
+    /* This constructor has been removed since it is not needed for cert req
     static {
         PrivilegedExceptionAction<Object[]> pa =
                 new PrivilegedExceptionAction<Object[]>() {
@@ -1443,7 +1443,7 @@ public class X500Name implements GeneralNameInterface, Principal {
                 + "X500Principal access").initCause(e);
         }
     }
-    SANDY */
+    end of removed constructor */
 
     /**
      * Get an X500Principal backed by this X500Name.

--- a/mas/src/androidTest/java/com/ca/mas/storage/MASSecureLocalStorageForApplicationTest.java
+++ b/mas/src/androidTest/java/com/ca/mas/storage/MASSecureLocalStorageForApplicationTest.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2016 CA. All rights reserved.
+ *
+ *  This software may be modified and distributed under the terms
+ *  of the MIT license.  See the LICENSE file for details.
+ *
+ */
+
+package com.ca.mas.storage;
+
+import com.ca.mas.foundation.MASConstants;
+
+public class MASSecureLocalStorageForApplicationTest extends MASSecureLocalStorageTest {
+    @Override
+    protected int getMode() {
+        return MASConstants.MAS_APPLICATION;
+    }
+
+
+}

--- a/mas/src/androidTest/java/com/ca/mas/storage/MASSecureLocalStorageTest.java
+++ b/mas/src/androidTest/java/com/ca/mas/storage/MASSecureLocalStorageTest.java
@@ -1,0 +1,268 @@
+/*
+ *  Copyright (c) 2016 CA. All rights reserved.
+ *
+ *  This software may be modified and distributed under the terms
+ *  of the MIT license.  See the LICENSE file for details.
+ *
+ */
+
+package com.ca.mas.storage;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.ca.mas.MASCallbackFuture;
+import com.ca.mas.MASLoginTestBase;
+import com.ca.mas.core.io.IoUtils;
+import com.ca.mas.foundation.MASConstants;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+
+@RunWith(AndroidJUnit4.class)
+public class MASSecureLocalStorageTest extends MASLoginTestBase {
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        MASCallbackFuture<Void> deleteAllUserDataCallback = new MASCallbackFuture<Void>();
+        getStorage().deleteAll(MASConstants.MAS_USER, deleteAllUserDataCallback);
+        deleteAllUserDataCallback.get();
+
+        MASCallbackFuture<Void> deleteAllApplicationDataCallback = new MASCallbackFuture<Void>();
+        getStorage().deleteAll(MASConstants.MAS_APPLICATION, deleteAllApplicationDataCallback);
+        deleteAllApplicationDataCallback.get();
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSaveNull() {
+        final String key = "key1";
+        String value = null;
+
+        getStorage().save(key, value, getMode(), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSaveWithNullKey() {
+        String key = null;
+        String value = "value1";
+        getStorage().save(key, value, getMode(), null);
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void testGetWithNullKey() {
+        String key = null;
+        getStorage().findByKey(key, getMode(), null);
+    }
+
+    @Test(expected = TypeNotPresentException.class)
+    public void testSaveUnsupportedData() throws Throwable {
+        String key = "key1";
+        Object unsupportedData = new Object();
+        MASCallbackFuture<Void> callbackFuture = new MASCallbackFuture<Void>();
+
+        getStorage().save(key, unsupportedData, getMode(), callbackFuture);
+        try {
+            callbackFuture.get();
+            fail();
+        } catch (ExecutionException e) {
+            throw e.getCause().getCause();
+        }
+    }
+
+    //byte][ operation(s)
+
+    @Test
+    public void testGetByteArray() throws ExecutionException, InterruptedException {
+        final String key = "key1";
+        byte[] value = "value1".getBytes();
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+
+        getStorage().save(key, value, getMode(), saveCallback);
+        saveCallback.get();
+        MASCallbackFuture<byte[]> findCallback = new MASCallbackFuture<byte[]>();
+
+        getStorage().findByKey(key, getMode(), findCallback);
+        Assert.assertEquals(new String(value), new String(findCallback.get()));
+    }
+
+
+    //String operations.
+    @Test
+    public void testSaveString() throws InterruptedException, ExecutionException {
+        final String key = "key1";
+        String value = "value1";
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+
+        getStorage().save(key, value, getMode(), saveCallback);
+        saveCallback.get();
+        MASCallbackFuture<String> findCallback = new MASCallbackFuture<String>();
+
+        getStorage().findByKey(key, getMode(), findCallback);
+        Assert.assertEquals(value, findCallback.get());
+    }
+
+    @Test
+    public void testSaveEmptyString() throws InterruptedException, ExecutionException {
+        final String key = "key1";
+        String value = "";
+
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+        getStorage().save(key, value, getMode(), saveCallback);
+        saveCallback.get();
+
+        MASCallbackFuture<String> findCallback = new MASCallbackFuture<String>();
+        getStorage().findByKey(key, getMode(), findCallback);
+        Assert.assertEquals(value, findCallback.get());
+    }
+
+
+    @Test
+    public void testUpdate() throws InterruptedException, ExecutionException {
+        final String key = "key1";
+        final String value = "value1";
+        final String value2 = "value2";
+
+
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+        getStorage().save(key, value, getMode(), saveCallback);
+        saveCallback.get();
+
+        MASCallbackFuture<Void> saveCallback2 = new MASCallbackFuture<Void>();
+        getStorage().save(key, value2, getMode(), saveCallback2);
+        saveCallback2.get();
+
+        MASCallbackFuture<String> findCallback = new MASCallbackFuture<String>();
+        getStorage().findByKey(key, getMode(), findCallback);
+        Assert.assertEquals(value2, findCallback.get());
+
+    }
+
+    @Test
+    public void testDeleteString() throws InterruptedException, ExecutionException {
+
+        final String key = "key1";
+        String value = "";
+
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+        getStorage().save(key, value, getMode(), saveCallback);
+        saveCallback.get();
+
+        MASCallbackFuture<Void> deleteCallback = new MASCallbackFuture<Void>();
+        getStorage().delete(key, getMode(), deleteCallback);
+        deleteCallback.get();
+
+        MASCallbackFuture findCallback = new MASCallbackFuture();
+        getStorage().findByKey(key, getMode(), findCallback);
+        Assert.assertNull(findCallback.get());
+
+    }
+
+
+    //JSON Operations
+    @Test
+    public void testSaveJson() throws JSONException, InterruptedException, ExecutionException {
+        final String key = "key1";
+        final JSONObject value = new JSONObject("{'storage':'localstore'}");
+
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+        getStorage().save(key, value, getMode(), saveCallback);
+        saveCallback.get();
+
+        MASCallbackFuture<JSONObject> findCallback = new MASCallbackFuture<JSONObject>();
+        getStorage().findByKey(key, getMode(), findCallback);
+        Assert.assertEquals(value.toString(), findCallback.get().toString());
+
+    }
+
+    //Bitmap Operation
+    @Test
+    public void testGetBitmap() throws InterruptedException, IOException, ExecutionException {
+        final String key = "key1";
+        Bitmap value = getImage("/samplepng.png");
+
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+        getStorage().save(key, value, getMode(), saveCallback);
+        saveCallback.get();
+
+        MASCallbackFuture<Bitmap> findCallback = new MASCallbackFuture<Bitmap>();
+        getStorage().findByKey(key, getMode(), findCallback);
+        Assert.assertNotNull(findCallback.get());
+
+    }
+
+    @Test
+    public void testSameKeyForUserAndApplication() throws Exception {
+        final String key = "key1";
+        final String value = "value1";
+        final String value2 = "value2";
+
+        MASCallbackFuture<Void> saveCallback = new MASCallbackFuture<Void>();
+        getStorage().save(key, value, MASConstants.MAS_USER, saveCallback);
+        saveCallback.get();
+
+        MASCallbackFuture<Void> saveCallback2 = new MASCallbackFuture<Void>();
+        getStorage().save(key, value2, MASConstants.MAS_APPLICATION, saveCallback2);
+        saveCallback2.get();
+
+        MASCallbackFuture<String> findCallback = new MASCallbackFuture<String>();
+        getStorage().findByKey(key, MASConstants.MAS_USER, findCallback);
+        Assert.assertEquals(value, findCallback.get());
+
+        MASCallbackFuture<String> findCallback2 = new MASCallbackFuture<String>();
+        getStorage().findByKey(key, MASConstants.MAS_APPLICATION, findCallback2);
+        Assert.assertEquals(value2, findCallback2.get());
+
+    }
+
+    @Test
+    public void testDeleteAll() throws Exception {
+        testSaveString();
+        MASCallbackFuture<Void> deleteCallback = new MASCallbackFuture<Void>();
+        getStorage().deleteAll(getMode(), deleteCallback);
+        MASCallbackFuture<Set<String>> keysetCallback = new MASCallbackFuture<Set<String>>();
+        getStorage().keySet(getMode(), keysetCallback);
+        assertTrue(keysetCallback.get().isEmpty());
+    }
+
+    // Utility methods.
+    private Bitmap getImage(String filePath) throws IOException {
+
+        byte[] bytes = IoUtils.slurpStream(getClass().getResourceAsStream(filePath), DEFAULT_MAX_RESPONSE_SIZE);
+        InputStream istr = null;
+        Bitmap bitmap = null;
+        istr = new ByteArrayInputStream(bytes);
+        bitmap = BitmapFactory.decodeStream(istr);
+        return bitmap;
+    }
+
+    protected
+    @MASStorageSegment
+    int getMode() {
+        return MASConstants.MAS_USER;
+    }
+
+    protected MASSecureLocalStorage getStorage() {
+        return new MASSecureLocalStorage();
+    }
+}


### PR DESCRIPTION
For rally 97380307676, ---- Created pull request for branch US97380307676_MASLockRequiredEncryptionProvider

Created a new EncryptionProviderScreenLockCanChange, although the default MASSecureLocalStorage will be using the original  DefaultEncryptionProvider.

This new EncryptionProviderScreenLockCanChange uses a new KeyStorageScreenLockCanChange.  The functionality is the same as the original DefaultEncryptionProvider except

1) For every key use, symm or asym, check with KeyguardManager to determine if the screen is protected with a pin/swipe/password.  If not, delete the keys.
2) Android KitKat and Lollipop: for all symm & asym, keys will setEncryptionRequred(false).  This is necessary to allow the screen lock to change, but leaves the keys vulnerable.  For Android KitKat, if setEncryptionRequred(true) the screen lock cannot change at all.  This is different for Lollipop, but we need to support both versions.
3) Android Marshmallow and Nougat: except in Lockable, userAuthenticationRequired to false, since it is not needed to protect the keys and to avoid problems with fingerprints
4) Also Added more documentation for KeyUtils and DefaultKeySymmetricManager.

https://rally1.rallydev.com/#/56296942493ud/detail/userstory/97380307676