### PR TITLE
Changed Get Started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ For more information about our mobile products see [the website][mas.ca.com].
 
 
 ## Get Started
-* Read the "[Getting Started][get-started]" guide or watch some [video tutorials][video].
-* Check out our [documentation][documentation] for more details and sample code.
+* Check out our [documentation][documentation] for more details and sample code, or watch some [video tutorials][video].
 
 
 ## Communication


### PR DESCRIPTION
The Get Started tab was removed from mas.ca.com.