### PR TITLE
De369138 charset for content types

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 - Persist all additional headers in a Multi-factor chain [DE71056]
+- Use content type of the Request instead of the ResponseBody default [DE369138]
 
 # Version 1.7.00
 

--- a/mas-foundation/src/androidTest/java/com/ca/mas/foundation/MASTest.java
+++ b/mas-foundation/src/androidTest/java/com/ca/mas/foundation/MASTest.java
@@ -21,6 +21,7 @@ import com.ca.mas.core.datasource.DataSourceFactory;
 import com.ca.mas.core.datasource.KeystoreDataSource;
 import com.ca.mas.core.error.TargetApiException;
 import com.ca.mas.core.http.ContentType;
+import com.ca.mas.core.io.Charsets;
 import com.ca.mas.core.oauth.OAuthServerException;
 import com.ca.mas.core.store.PrivateTokenStorage;
 import com.squareup.okhttp.mockwebserver.MockResponse;
@@ -529,6 +530,40 @@ public class MASTest extends MASLoginTestBase {
         assertEquals(requestData, new String(recordedRequest.getBody().readUtf8()));
         assertEquals(RESPONSE_HEADER_VALUE, recordedRequest.getHeader(RESPONSE_HEADER_NAME));
     }
+
+    @Test
+    public void testHttpOverrideCharset() throws Exception {
+        String requestData = "Expected Request Data";
+        final ContentType customCharset = new ContentType("application/x-www-form-urlencoded", Charsets.UTF8);
+
+        setDispatcher(new GatewayDefaultDispatcher() {
+            @Override
+            protected MockResponse other() {
+                return new MockResponse().
+                        setResponseCode(HttpURLConnection.HTTP_OK).
+                        setHeader("Content-Type", customCharset.toString()).
+                        setHeader(RESPONSE_HEADER_NAME, RESPONSE_HEADER_VALUE).
+                        setBody(RESPONSE_DATA);
+            }
+        });
+
+        Uri uri = new Uri.Builder().
+                appendEncodedPath(GatewayDefaultDispatcher.OTHER).
+                appendQueryParameter(QUERY_PARAMETER_NAME, QUERY_PARAMETER_VALUE).build();
+
+        MASRequest request = new MASRequest.MASRequestBuilder(uri)
+                .post(MASRequestBody.stringBody(requestData))
+                .header("Content-Type", customCharset.toString())
+                .header(RESPONSE_HEADER_NAME, RESPONSE_HEADER_VALUE)
+                .build();
+
+        MASCallbackFuture<MASResponse<String>> callback = new MASCallbackFuture<>();
+        MAS.invoke(request, callback);
+
+        String header = request.getHeaders().get("Content-Type").get(0);
+        assertEquals(header, callback.get().getBody().getContentType());
+    }
+
 
     @Test
     public void testHttpPostWithJson() throws Exception {

--- a/mas-foundation/src/main/java/com/ca/mas/core/http/MAGHttpClient.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/http/MAGHttpClient.java
@@ -106,8 +106,11 @@ public class MAGHttpClient {
                         urlConnection.setChunkedStreamingMode(0);
                     }
                 }
-                if (body.getContentType() != null) {
-                    urlConnection.setRequestProperty("Content-Type", body.getContentType().toString());
+                if (body.getContentType() != null && request.getHeaders() != null) {
+                    List<String> reqHeader = request.getHeaders().get("Content-Type");
+                    if (reqHeader == null) {
+                        urlConnection.setRequestProperty("Content-Type", body.getContentType().toString());
+                    }
                 }
                 if (request.getConnectionListener() != null) {
                     request.getConnectionListener().onConnected(urlConnection);


### PR DESCRIPTION
De369138 charset for content types
- If request has Content-Type header do not use the requestbody default one
- tests