### PR TITLE
For static clients JWT validation fails due to unavailable secret

### DIFF
--- a/mas-foundation/src/androidTest/java/com/ca/mas/foundation/MASJWTRS256ValidatorTest.java
+++ b/mas-foundation/src/androidTest/java/com/ca/mas/foundation/MASJWTRS256ValidatorTest.java
@@ -8,16 +8,12 @@
 
 package com.ca.mas.foundation;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-
 import com.ca.mas.MASMockGatewayTestBase;
-import com.ca.mas.TestUtils;
+import com.ca.mas.core.context.MssoContext;
 import com.ca.mas.core.token.IdToken;
 import com.ca.mas.core.token.JWTRS256Validator;
 import com.ca.mas.core.token.JWTValidationException;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,7 +26,7 @@ public class MASJWTRS256ValidatorTest extends MASMockGatewayTestBase {
         MAS.start(getContext());
         IdToken idToken = new IdToken("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjo5OTk5OTk5OTk5LCJhdWQiOiJkdW1teSIsImF6cCI6ImY0NzM1MjVkLWMxMzAtNGJiYS04NmNjLWRiMjZkODg3NTM4NiJ9.Q25Tm1yqs-KLR_qX-t6iuq38K_yFeobil3oMAXx9E2L1ds-DUG6tzm3BNQZUTQdNALRI47pGJUF4ZLJkqyC-z_THqwZwBq9ISfalmDxmSdf_ec7qt6Ll-mFj7epAfMY5JsEG7YO6ReDmfToke95ZJup9x25GHZOuH_gyiSd94SM", "urn:ietf:params:oauth:grant-type:jwt-bearer");
         JWTRS256Validator jwtrs256Validator = new JWTRS256Validator();
-        jwtrs256Validator.validate(idToken);
+        jwtrs256Validator.validate(MssoContext.newContext(), idToken);
     }
 
     @Test(expected = JWTValidationException.class)
@@ -38,7 +34,7 @@ public class MASJWTRS256ValidatorTest extends MASMockGatewayTestBase {
         MAS.start(getContext());
         IdToken idToken = new IdToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRlZmF1bHRfc3NsX2tleSJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjo5OTk5OTk5OTk5LCJhdWQiOiJkdW1teSIsImF6cCI6ImY0NzM1MjVkLWMxMzAtNGJiYS04NmNjLWRiMjZkODg3NTM4NiJ9.Q25Tm1yqs-KLR_qX-t6iuq38K_yFeobil3oMAXx9E2L1ds-DUG6tzm3BNQZUTQdNALRI47pGJUF4ZLJkqyC-z_THqwZwBq9ISfalmDxmSdf_ec7qt6Ll-mFj7epAfMY5JsEG7YO6ReDmfToke95ZJup9x25GHZOuH_gyiSd94SM", "urn:ietf:params:oauth:grant-type:jwt-bearer");
         JWTRS256Validator jwtrs256Validator = new JWTRS256Validator();
-        jwtrs256Validator.validate(idToken);
+        jwtrs256Validator.validate(MssoContext.newContext(), idToken);
     }
 
     @Test(expected = JWTValidationException.class)
@@ -46,7 +42,7 @@ public class MASJWTRS256ValidatorTest extends MASMockGatewayTestBase {
         MAS.start(getContext());
         IdToken idToken = new IdToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRlZmF1bHRfa2V5In0=.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjo5OTk5OTk5OTk5LCJhdWQiOiJkdW1teSIsImF6cCI6ImY0NzM1MjVkLWMxMzAtNGJiYS04NmNjLWRiMjZkODg3NTM4NiJ9.Q25Tm1yqs-KLR_qX-t6iuq38K_yFeobil3oMAXx9E2L1ds-DUG6tzm3BNQZUTQdNALRI47pGJUF4ZLJkqyC-z_THqwZwBq9ISfalmDxmSdf_ec7qt6Ll-mFj7epAfMY5JsEG7YO6ReDmfToke95ZJup9x25GHZOuH_gyiSd94SM", "urn:ietf:params:oauth:grant-type:jwt-bearer");
         JWTRS256Validator jwtrs256Validator = new JWTRS256Validator();
-        jwtrs256Validator.validate(idToken);
+        jwtrs256Validator.validate(MssoContext.newContext(), idToken);
     }
 
     @Test
@@ -54,7 +50,7 @@ public class MASJWTRS256ValidatorTest extends MASMockGatewayTestBase {
         MAS.start(getContext());
         IdToken idToken = new IdToken("eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImRlZmF1bHRfc3NsX2tleSJ9.ewogInN1YiI6ICJlaHAxdzVrN3pVdFRrRWYyWEUtSUxuREFhU3FsRHZrY1VXSjZTTTNEUFNzIiwKICJhdWQiOiAiMDdmNjFlNmUtZTE2NC00MTRlLTkyNTItMzMzOTgwOTBmOTAwIiwKICJhY3IiOiAiMCIsCiAiYXpwIjogIllVdEpkR2haZW1kcldteFdkazFpYVRsMU5rTTJkazFYYTNsdlBRPT0iLAogImF1dGhfdGltZSI6IDE1MzkwNzU0OTgsCiAiaXNzIjogImh0dHBzOi8vbWFnZmlkby5jYS5jb206ODQ0MyIsCiAiZXhwIjogMTUzOTE2MTg5OCwKICJpYXQiOiAxNTM5MDc1NDk4Cn0.bW-mEvwxS8AgGWjtpN_DhxobVusW3212m54iK030zcyhBQLUK2M_HJFjVBZByZoMqNLp9zflD8lbxZiOI_JOS3O2ca60gLyvWdEDsZO5dCyMeHZb_6T4FjXRn3v2BktF7raJjRWDfIZRcRZKSLXezig1HFSSYasXlkHyP1vwqs-r_c2oYVmmwQubdcp-PObhqxjO8PGRCB58eYX6lkMXj3AAnl1jeuRmHUns24WjgSWBXQFhSxwJOiXfTajh-bzbjnpeWsKEgVI7BGuIvdIm_YagVo8l3K68dHtuhqTwqiOv9K_z4GlJezdzj4ipx3Wkjm_RjayIWZSLz3-A3AvzWA", "urn:ietf:params:oauth:grant-type:jwt-bearer");
         JWTRS256Validator jwtrs256Validator = new JWTRS256Validator();
-        Assert.assertTrue(jwtrs256Validator.validate(idToken));
+        Assert.assertTrue(jwtrs256Validator.validate(MssoContext.newContext(), idToken));
     }
 
 

--- a/mas-foundation/src/androidTest/java/com/ca/mas/foundation/MASJwtSigningTest.java
+++ b/mas-foundation/src/androidTest/java/com/ca/mas/foundation/MASJwtSigningTest.java
@@ -14,6 +14,7 @@ import com.ca.mas.DataSource;
 import com.ca.mas.GatewayDefaultDispatcher;
 import com.ca.mas.MASCallbackFuture;
 import com.ca.mas.MASLoginTestBase;
+import com.ca.mas.core.context.MssoContext;
 import com.ca.mas.core.http.ContentType;
 import com.ca.mas.core.security.KeyStoreException;
 import com.ca.mas.core.store.ClientCredentialContainer;
@@ -265,7 +266,7 @@ public class MASJwtSigningTest extends MASLoginTestBase {
         String clientId = "e8f427b3-02e3-4810-8424-369b1319b5df";
         String clientSecret = cc.getClientSecret();
         // - validate the token
-        Assert.assertTrue(JWTValidation.validateIdToken(idToken, deviceIdentifier, clientId, clientSecret));
+        Assert.assertTrue(JWTValidation.validateIdToken(MssoContext.newContext(), idToken, deviceIdentifier, clientId, clientSecret));
     }
 
     @Test(expected = JWTValidationException.class)
@@ -278,7 +279,7 @@ public class MASJwtSigningTest extends MASLoginTestBase {
         String clientId = cc.getClientId();
         String clientSecret = cc.getClientSecret();
         // - validate the token
-        JWTValidation.validateIdToken(idToken, deviceIdentifier, clientId, clientSecret);
+        JWTValidation.validateIdToken(MssoContext.newContext(), idToken, deviceIdentifier, clientId, clientSecret);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
@@ -287,7 +287,7 @@ public class MssoContext {
         String clientSecret = getClientSecret();
 
         if (idToken.getType().equals(IdToken.JWT_DEFAULT)) {
-            if (JWTValidation.validateIdToken(idToken, deviceIdentifier, clientId, clientSecret)) {
+            if (JWTValidation.validateIdToken(this,idToken, deviceIdentifier, clientId, clientSecret)) {
                 setIdToken(idToken);
             } else {
                 throw new JWTValidationException(MAGErrorCode.TOKEN_INVALID_ID_TOKEN, "JWT Token is not valid");

--- a/mas-foundation/src/main/java/com/ca/mas/core/token/JWTHmacValidator.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/token/JWTHmacValidator.java
@@ -9,27 +9,22 @@
 package com.ca.mas.core.token;
 
 import android.util.Base64;
-import android.util.Log;
 
 import com.ca.mas.core.context.MssoContext;
-import com.ca.mas.core.store.StorageProvider;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
-import static com.ca.mas.foundation.MAS.DEBUG;
-import static com.ca.mas.foundation.MAS.TAG;
-
 class JWTHmacValidator implements  JWTValidator{
 
     @Override
-    public boolean validate(IdToken token) throws JWTValidationException {
+    public boolean validate(MssoContext context,IdToken token) throws JWTValidationException {
 
         IdTokenDef idTokenDef = new IdTokenDef(token);
         byte[] header = idTokenDef.getHeader();
         byte[] payload = idTokenDef.getPayload();
         byte[] signature = idTokenDef.getSignature();
-        String clientSecret = StorageProvider.getInstance().getClientCredentialContainer().getClientSecret();
+        String clientSecret = context.getClientSecret();
         byte[] signToCompare = signData(header, payload, clientSecret.getBytes());
         byte[] decodedSignature = Base64.decode(signature, Base64.URL_SAFE);
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/token/JWTRS256Validator.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/token/JWTRS256Validator.java
@@ -17,6 +17,7 @@ import android.util.Log;
 
 import com.ca.mas.core.MASCallbackFuture;
 import com.ca.mas.core.conf.ConfigurationManager;
+import com.ca.mas.core.context.MssoContext;
 import com.ca.mas.core.error.MAGErrorCode;
 import com.ca.mas.core.http.MAGHttpClient;
 import com.ca.mas.foundation.MAS;
@@ -85,7 +86,7 @@ public class JWTRS256Validator implements JWTValidator {
      * @return boolean True if signature is valid else false.
      */
     @Override
-    public boolean validate(final @NonNull IdToken idToken) throws JWTValidationException {
+    public boolean validate(MssoContext context,final @NonNull IdToken idToken) throws JWTValidationException {
 
         boolean isSignatureValid;
         IdTokenDef idTokenDef = new IdTokenDef(idToken);

--- a/mas-foundation/src/main/java/com/ca/mas/core/token/JWTValidation.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/token/JWTValidation.java
@@ -11,6 +11,7 @@ package com.ca.mas.core.token;
 import android.util.Base64;
 import android.util.Log;
 
+import com.ca.mas.core.context.MssoContext;
 import com.ca.mas.core.error.MAGErrorCode;
 import com.ca.mas.foundation.MAS;
 
@@ -46,7 +47,7 @@ public class JWTValidation {
         return false;
     }
 
-    public static boolean validateIdToken(IdToken idToken, String deviceIdentifier, String clientId, String clientSecret) throws JWTValidationException {
+    public static boolean validateIdToken(MssoContext context,IdToken idToken, String deviceIdentifier, String clientId, String clientSecret) throws JWTValidationException {
 
         boolean isValid = false;
 
@@ -62,7 +63,7 @@ public class JWTValidation {
         boolean idTokenValidationEnabled = MAS.isIdTokenValidationEnabled();
 
         if (algorithm != null && idTokenValidationEnabled) {
-            signatureValid = JWTValidatorFactory.getValidator(algorithm).validate(idToken);
+            signatureValid = JWTValidatorFactory.getValidator(algorithm).validate(context,idToken);
         }
 
         if (!idTokenValidationEnabled){

--- a/mas-foundation/src/main/java/com/ca/mas/core/token/JWTValidator.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/token/JWTValidator.java
@@ -1,6 +1,8 @@
 package com.ca.mas.core.token;
 
+import com.ca.mas.core.context.MssoContext;
+
 public interface JWTValidator {
 
-    public boolean validate(IdToken token) throws JWTInvalidSignatureException, JWTValidationException;
+    public boolean validate(MssoContext context,IdToken token) throws JWTInvalidSignatureException, JWTValidationException;
 }


### PR DESCRIPTION
Classes changed to pass MssoContext object around, which should be used to fetch client_id and secret instead of StorageProvider native implementaiton.