### PR TITLE
PATCH Http method support

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/http/MAGHttpClient.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/http/MAGHttpClient.java
@@ -85,7 +85,13 @@ public class MAGHttpClient {
                 ConfigurationManager.getInstance().getConnectionListener().onObtained(urlConnection);
             }
 
-            urlConnection.setRequestMethod(request.getMethod());
+            if (request.getMethod().equals("PATCH") && Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                urlConnection.setRequestProperty("X-HTTP-Method-Override", "PATCH");
+                urlConnection.setRequestMethod("POST");
+            } else {
+                urlConnection.setRequestMethod(request.getMethod());
+            }
+
             urlConnection.setDoInput(true);
             for (String key : request.getHeaders().keySet()) {
                 if (request.getHeaders().get(key) != null) {

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASRequest.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASRequest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
  */
 public interface MASRequest {
 
-    enum Method {GET, PUT, POST, DELETE}
+    enum Method {GET, PUT, POST, DELETE, PATCH}
 
     /**
      * @return URL of this request
@@ -218,6 +218,18 @@ public interface MASRequest {
          */
         public MASRequestBuilder put(MASRequestBody body) {
             this.method = Method.PUT.name();
+            this.body = body;
+            return this;
+        }
+
+        /**
+         * Sets the request method to PATCH with {@link MASRequestBody}
+         *
+         * @param body The MAGRequestBody to PUT with.
+         * @return The builder
+         */
+        public MASRequestBuilder patch(MASRequestBody body) {
+            this.method = Method.PATCH.name();
             this.body = body;
             return this;
         }

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASRequest.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASRequest.java
@@ -225,7 +225,7 @@ public interface MASRequest {
         /**
          * Sets the request method to PATCH with {@link MASRequestBody}
          *
-         * @param body The MAGRequestBody to PUT with.
+         * @param body The MAGRequestBody to PATCH with.
          * @return The builder
          */
         public MASRequestBuilder patch(MASRequestBody body) {


### PR DESCRIPTION
Hello,

We're implementing MAS SDK, but notice that HTTP method PATCH was missing.
After research I found that HttpUrlConnection don't support native PATCH method only on API < 19. 

If server supports, even in lower API's we can send POST method with additional header "X-HTTP-Method-Override"
Our min SDK version is 22 at the moment, so we could use PATCH regardless of CA gateway  HTTP-Method-Override support.

This fix was based on following issue: https://github.com/OneDrive/onedrive-sdk-android/issues/16

Thanks
