### PR TITLE
Delete the refresh token only for the valid scenarios

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
@@ -10,6 +10,7 @@ package com.ca.mas.core.oauth;
 
 import androidx.annotation.NonNull;
 import android.util.Pair;
+import android.util.Log;
 
 import com.ca.mas.core.MobileSsoConfig;
 import com.ca.mas.core.client.ServerClient;
@@ -23,12 +24,15 @@ import com.ca.mas.core.token.IdToken;
 import com.ca.mas.foundation.MASRequest;
 import com.ca.mas.foundation.MASRequestBody;
 import com.ca.mas.foundation.MASResponseBody;
+import static com.ca.mas.foundation.MAS.DEBUG;
+import static com.ca.mas.foundation.MAS.TAG;
 
 import org.json.JSONException;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+
 
 /**
  * Utility class that encapsulates talking to the token server into Java method calls.
@@ -176,16 +180,18 @@ public class OAuthTokenClient extends ServerClient {
                 .build();
 
         OAuthTokenResponse tokenResponse = null;
-
-        //Remove refresh token once we get a proper response from the server, no matter success or not.
-        mssoContext.takeRefreshToken();
-
         try {
             tokenResponse = new OAuthTokenResponse(obtainServerResponseToPostedForm(tokenRequest));
+            if(tokenRequest != null){
+                //Remove refresh token once we get a proper response from the server
+                mssoContext.takeRefreshToken();
+            }
             validate(tokenResponse);
         } catch (JSONException | MAGException e) {
             throw new OAuthException(MAGErrorCode.ACCESS_TOKEN_INVALID, e);
         } catch (MAGServerException e) {
+            //Remove refresh token once we get any server exception
+            mssoContext.takeRefreshToken();
             throw new OAuthServerException(e);
         }
         return tokenResponse;

--- a/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
@@ -181,15 +181,17 @@ public class OAuthTokenClient extends ServerClient {
         try {
             tokenResponse = new OAuthTokenResponse(obtainServerResponseToPostedForm(tokenRequest));
             if(tokenRequest != null){
+                validate(tokenResponse);
                 //Remove refresh token once we get a proper response from the server
                 mssoContext.takeRefreshToken();
             }
-            validate(tokenResponse);
         } catch (JSONException | MAGException e) {
             throw new OAuthException(MAGErrorCode.ACCESS_TOKEN_INVALID, e);
         } catch (MAGServerException e) {
-            //Remove refresh token once we get any server exception
-            mssoContext.takeRefreshToken();
+            if(e.getResponse()!= null){
+                //Remove refresh token once we get any server exception
+                mssoContext.takeRefreshToken();
+            }
             throw new OAuthServerException(e);
         }
         return tokenResponse;

--- a/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
@@ -10,7 +10,6 @@ package com.ca.mas.core.oauth;
 
 import androidx.annotation.NonNull;
 import android.util.Pair;
-import android.util.Log;
 
 import com.ca.mas.core.MobileSsoConfig;
 import com.ca.mas.core.client.ServerClient;
@@ -24,8 +23,7 @@ import com.ca.mas.core.token.IdToken;
 import com.ca.mas.foundation.MASRequest;
 import com.ca.mas.foundation.MASRequestBody;
 import com.ca.mas.foundation.MASResponseBody;
-import static com.ca.mas.foundation.MAS.DEBUG;
-import static com.ca.mas.foundation.MAS.TAG;
+
 
 import org.json.JSONException;
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/oauth/OAuthTokenClient.java
@@ -180,11 +180,9 @@ public class OAuthTokenClient extends ServerClient {
         OAuthTokenResponse tokenResponse = null;
         try {
             tokenResponse = new OAuthTokenResponse(obtainServerResponseToPostedForm(tokenRequest));
-            if(tokenRequest != null){
-                validate(tokenResponse);
-                //Remove refresh token once we get a proper response from the server
-                mssoContext.takeRefreshToken();
-            }
+            validate(tokenResponse);
+            //Remove refresh token once we get a proper response from the server
+            mssoContext.takeRefreshToken();
         } catch (JSONException | MAGException e) {
             throw new OAuthException(MAGErrorCode.ACCESS_TOKEN_INVALID, e);
         } catch (MAGServerException e) {

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
@@ -256,8 +256,10 @@ class AccessTokenAssertion implements MssoAssertion {
 
             rethrowOrIgnore(tse);
 
-            //The access token and refresh token are no longer valid.
-            mssoContext.clearAccessToken();
+            if(tse.getResponse()!= null){
+                //The access token and refresh token are no longer valid.
+                mssoContext.clearAccessToken(); 
+            }
             accessToken = null;
             if (DEBUG) Log.w(TAG,
                     "Refresh token failed, will fall back to ID token or password: " + tse.getMessage(), tse);


### PR DESCRIPTION
Earlier we were deleting the refresh token irrespective of the success/failure scenario. Due to that, if there is no internet connection and application is trying to fetch the access token using refresh token, it is going to login page although access token is not expired. This is because we are not checking the condition before deleting the refresh token. 

Now we are deleting the refresh token if we are receiving proper response or we are getting Server Exception.