### PR TITLE
De473035 bugfix SCIM call

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ For more information about our mobile products see the [developer website](http:
 * **Enterprise Browser** - Extend the single sign-on session to web applications.
 * **Proximity Login** - Transfer the user session between devices and platforms.
 * **Fingerprint Sessions Lock** - Support phone unlocking using fingerprint recognition.
-* **Private Cloud Storage** - Store data in a private cloud and access it from all of your devices.
 * **Pub/Sub** - Create real-time, IoT-friendly apps using an MQTT-based Pub/Sub infrastructure.
 * **Adhoc Groups** - Create groups on-the-fly for collaborative apps.
 * **Local Storage** - Store data on devices with enterprise-grade encryption.

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
     minSdkVersion = 19
     nimbusJoseVersion = '8.6'
     targetSdkVersion = 29
-    versionCode = 23
+    versionCode = 24
     versionName = '2.1.00'
     zxingVersion = '3.4.0'
     testRunner = '1.0.1'

--- a/mas-foundation/src/main/java/com/ca/mas/identity/user/MASUserRepositoryImpl.java
+++ b/mas-foundation/src/main/java/com/ca/mas/identity/user/MASUserRepositoryImpl.java
@@ -80,30 +80,38 @@ public class MASUserRepositoryImpl implements MASUserRepository {
     public void getUserById(String id, final MASCallback<MASUser> callback) {
         Uri.Builder builder = new Uri.Builder();
         String path = IdentityUtil.getUserPath();
-        builder.appendEncodedPath(path.startsWith(IdentityConsts.FSLASH) ? path.substring(1) : path);
-        builder.appendPath(id);
-        MASRequest masRequest = new MASRequest.MASRequestBuilder(builder.build())
-                .header(IdentityConsts.HEADER_KEY_ACCEPT, IdentityConsts.HEADER_VALUE_ACCEPT)
-                .header(IdentityConsts.HEADER_KEY_CONTENT_TYPE, IdentityConsts.HEADER_VALUE_CONTENT_TYPE)
-                .responseBody(MASResponseBody.jsonBody())
-                .get()
-                .build();
-
-        MAS.invoke(masRequest, new MASCallback<MASResponse<JSONObject>>() {
-            @Override
-            public void onSuccess(MASResponse<JSONObject> result) {
-                try {
-                    Callback.onSuccess(callback, processUserById(result.getBody().getContent()));
-                } catch (JSONException e) {
-                    Callback.onError(callback, e);
-                }
-            }
-
-            @Override
-            public void onError(Throwable e) {
+        if (path.equals("/SCIM/MAS/v2/Users")) {
+            try {
+                throw new Exception("Bypassing SCIM call");
+            } catch (Exception e) {
                 Callback.onError(callback, e);
             }
-        });
+        } else {
+            builder.appendEncodedPath(path.startsWith(IdentityConsts.FSLASH) ? path.substring(1) : path);
+            builder.appendPath(id);
+            MASRequest masRequest = new MASRequest.MASRequestBuilder(builder.build())
+                    .header(IdentityConsts.HEADER_KEY_ACCEPT, IdentityConsts.HEADER_VALUE_ACCEPT)
+                    .header(IdentityConsts.HEADER_KEY_CONTENT_TYPE, IdentityConsts.HEADER_VALUE_CONTENT_TYPE)
+                    .responseBody(MASResponseBody.jsonBody())
+                    .get()
+                    .build();
+
+            MAS.invoke(masRequest, new MASCallback<MASResponse<JSONObject>>() {
+                @Override
+                public void onSuccess(MASResponse<JSONObject> result) {
+                    try {
+                        Callback.onSuccess(callback, processUserById(result.getBody().getContent()));
+                    } catch (JSONException e) {
+                        Callback.onError(callback, e);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    Callback.onError(callback, e);
+                }
+            });
+        }
     }
 
     @Override

--- a/mas-foundation/src/main/java/com/ca/mas/identity/util/IdentityUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/identity/util/IdentityUtil.java
@@ -113,7 +113,7 @@ public class IdentityUtil {
             sb.append(FoundationConsts.FSLASH);
             sb.append(entity);
         }
-        if (DEBUG) Log.d(TAG, "SCIM URL Path: " + sb.toString());
+       // if (DEBUG) Log.d(TAG, "SCIM URL Path: " + sb.toString());
         return sb.toString();
     }
 


### PR DESCRIPTION
In order to block the SCIM call, in MASUserRepositoryImpl.java file an exception is created and in the catch block Callback.onError(callback, e) is called so that the remaining api calls which have to be executed after the SCIM call are not blocked.