### PR TITLE
Defect/de481799 update clear access token

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
@@ -325,7 +325,14 @@ public class MssoContext {
      * Clear the access token, forcing the next request to obtain a new one.
      */
     public void clearAccessToken() {
-        privateTokens.clear();
+        privateTokens.clearAccessToken();
+    }
+
+    /**
+     * Clears the access token and refresh token, leaving the ID token, if present.
+     */
+    public void clearAccessAndRefreshTokens() { 
+        privateTokens.clear(); 
     }
 
     /**

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
@@ -122,14 +122,15 @@ class AccessTokenAssertion implements MssoAssertion {
             } else {
                 accessToken = null;
             }
+        }
 
-            String refreshToken = mssoContext.getRefreshToken();
-            if (refreshToken != null) {
-                accessToken = obtainAccessTokenUsingRefreshToken(mssoContext, refreshToken);
-            }
+        String refreshToken = mssoContext.getRefreshToken();
+        if (refreshToken != null) {
+            accessToken = obtainAccessTokenUsingRefreshToken(mssoContext, refreshToken);
+        }
 
-            if (accessToken != null)
-                return accessToken;
+        if (accessToken != null) {
+            return accessToken;
         }
 
         // Obtain an access token from the token server.
@@ -258,7 +259,7 @@ class AccessTokenAssertion implements MssoAssertion {
 
             if(tse.getResponse()!= null){
                 //The access token and refresh token are no longer valid.
-                mssoContext.clearAccessToken(); 
+                mssoContext.clearAccessAndRefreshTokens();
             }
             accessToken = null;
             if (DEBUG) Log.w(TAG,

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/SecureLockAssertion.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/SecureLockAssertion.java
@@ -44,7 +44,7 @@ class SecureLockAssertion implements MssoAssertion {
             if (revokeRequest != null) {
                 MAS.invoke(OAuthClientUtil.getRevokeRequest(), null);
             }
-            mssoContext.clearAccessToken();
+            mssoContext.clearAccessAndRefreshTokens();
             throw new SecureLockException("The session is currently locked.");
         }
     }

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/exceptions/InvalidClientCredentialException.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/exceptions/InvalidClientCredentialException.java
@@ -27,7 +27,7 @@ public class InvalidClientCredentialException extends RetryRequestException {
 
     @Override
     public void recover(MssoContext context) {
-        context.clearAccessToken();
+        context.clearAccessAndRefreshTokens();
         context.clearClientCredentials();
     }
 }

--- a/mas-foundation/src/main/java/com/ca/mas/core/store/OAuthTokenContainer.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/store/OAuthTokenContainer.java
@@ -25,6 +25,8 @@ public interface OAuthTokenContainer {
      */
     long getExpiry();
 
+    void clearAccessToken();
+
     void clear();
 
     void clearAll();

--- a/mas-foundation/src/main/java/com/ca/mas/core/store/PrivateTokenStorage.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/store/PrivateTokenStorage.java
@@ -97,6 +97,12 @@ public class PrivateTokenStorage implements OAuthTokenContainer {
     }
 
     @Override
+    public void clearAccessToken() {
+        storage.remove(getKey(KEY.PREF_ACCESS_TOKEN.name()));
+        storage.remove(getKey(KEY.PREF_EXPIRY_UNIXTIME.name()));
+    }
+
+    @Override
     public void clear() {
         for (KEY k : KEY.values()) {
             storage.remove(getKey(k.name()));

--- a/mas-foundation/src/main/java/com/ca/mas/identity/user/MASUserRepositoryImpl.java
+++ b/mas-foundation/src/main/java/com/ca/mas/identity/user/MASUserRepositoryImpl.java
@@ -80,30 +80,38 @@ public class MASUserRepositoryImpl implements MASUserRepository {
     public void getUserById(String id, final MASCallback<MASUser> callback) {
         Uri.Builder builder = new Uri.Builder();
         String path = IdentityUtil.getUserPath();
-        builder.appendEncodedPath(path.startsWith(IdentityConsts.FSLASH) ? path.substring(1) : path);
-        builder.appendPath(id);
-        MASRequest masRequest = new MASRequest.MASRequestBuilder(builder.build())
-                .header(IdentityConsts.HEADER_KEY_ACCEPT, IdentityConsts.HEADER_VALUE_ACCEPT)
-                .header(IdentityConsts.HEADER_KEY_CONTENT_TYPE, IdentityConsts.HEADER_VALUE_CONTENT_TYPE)
-                .responseBody(MASResponseBody.jsonBody())
-                .get()
-                .build();
-
-        MAS.invoke(masRequest, new MASCallback<MASResponse<JSONObject>>() {
-            @Override
-            public void onSuccess(MASResponse<JSONObject> result) {
-                try {
-                    Callback.onSuccess(callback, processUserById(result.getBody().getContent()));
-                } catch (JSONException e) {
-                    Callback.onError(callback, e);
-                }
-            }
-
-            @Override
-            public void onError(Throwable e) {
+        if (path.equals("/SCIM/MAS/v2/Users")) {
+            try {
+                throw new Exception("Bypassing SCIM call");
+            } catch (Exception e) {
                 Callback.onError(callback, e);
             }
-        });
+        } else {
+            builder.appendEncodedPath(path.startsWith(IdentityConsts.FSLASH) ? path.substring(1) : path);
+            builder.appendPath(id);
+            MASRequest masRequest = new MASRequest.MASRequestBuilder(builder.build())
+                    .header(IdentityConsts.HEADER_KEY_ACCEPT, IdentityConsts.HEADER_VALUE_ACCEPT)
+                    .header(IdentityConsts.HEADER_KEY_CONTENT_TYPE, IdentityConsts.HEADER_VALUE_CONTENT_TYPE)
+                    .responseBody(MASResponseBody.jsonBody())
+                    .get()
+                    .build();
+
+            MAS.invoke(masRequest, new MASCallback<MASResponse<JSONObject>>() {
+                @Override
+                public void onSuccess(MASResponse<JSONObject> result) {
+                    try {
+                        Callback.onSuccess(callback, processUserById(result.getBody().getContent()));
+                    } catch (JSONException e) {
+                        Callback.onError(callback, e);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    Callback.onError(callback, e);
+                }
+            });
+        }
     }
 
     @Override

--- a/mas-foundation/src/main/java/com/ca/mas/identity/util/IdentityUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/identity/util/IdentityUtil.java
@@ -113,7 +113,7 @@ public class IdentityUtil {
             sb.append(FoundationConsts.FSLASH);
             sb.append(entity);
         }
-        if (DEBUG) Log.d(TAG, "SCIM URL Path: " + sb.toString());
+       // if (DEBUG) Log.d(TAG, "SCIM URL Path: " + sb.toString());
         return sb.toString();
     }
 


### PR DESCRIPTION
Here introduces a separate method clearAccessAndRefreshTokens for the cases where both token types should be cleared from the private token storage, and changes the current implementation of clearAccessToken to clear only the access token while leaving the refresh token intact.

The logic in AccessTokenAssertion.findAccessToken is also updated for the case where the access token has been cleared, but a valid refresh token is available. The library should first try to update with the refresh token before reverting to the ID token.

Also it includes the refresh token deletion based on conditional check and SCIM call fix. 