### PR TITLE
Integrate the Sun Library fix for Turkish language

### DIFF
--- a/mas-foundation/src/main/java/sun/security/pkcs/PKCS9Attribute.java
+++ b/mas-foundation/src/main/java/sun/security/pkcs/PKCS9Attribute.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 1997-2006 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,9 +18,9 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package sun.security.pkcs;
@@ -28,17 +28,17 @@ package sun.security.pkcs;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.cert.CertificateException;
+import java.util.Locale;
 import java.util.Date;
 import java.util.Hashtable;
-
-import sun.misc.HexDumpEncoder;
+import sun.security.x509.CertificateExtensions;
 import sun.security.util.Debug;
 import sun.security.util.DerEncoder;
+import sun.security.util.DerValue;
 import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
-import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
-import sun.security.x509.CertificateExtensions;
+import sun.misc.HexDumpEncoder;
 
 /**
  * Class supporting any PKCS9 attributes.
@@ -188,14 +188,14 @@ public class PKCS9Attribute implements DerEncoder {
     static {   // static initializer for PKCS9_OIDS
         for (int i = 1; i < PKCS9_OIDS.length - 2; i++) {
             PKCS9_OIDS[i] =
-                ObjectIdentifier.newInternal(new int[]{1,2,840,113549,1,9,i});
+                    ObjectIdentifier.newInternal(new int[]{1,2,840,113549,1,9,i});
         }
         // Initialize SigningCertificate and SignatureTimestampToken
         // separately (because their values are out of sequence)
         PKCS9_OIDS[PKCS9_OIDS.length - 2] =
-            ObjectIdentifier.newInternal(new int[]{1,2,840,113549,1,9,16,2,12});
+                ObjectIdentifier.newInternal(new int[]{1,2,840,113549,1,9,16,2,12});
         PKCS9_OIDS[PKCS9_OIDS.length - 1] =
-            ObjectIdentifier.newInternal(new int[]{1,2,840,113549,1,9,16,2,14});
+                ObjectIdentifier.newInternal(new int[]{1,2,840,113549,1,9,16,2,14});
     }
 
     // first element [0] not used
@@ -208,7 +208,7 @@ public class PKCS9Attribute implements DerEncoder {
     public static final ObjectIdentifier CHALLENGE_PASSWORD_OID = PKCS9_OIDS[7];
     public static final ObjectIdentifier UNSTRUCTURED_ADDRESS_OID = PKCS9_OIDS[8];
     public static final ObjectIdentifier EXTENDED_CERTIFICATE_ATTRIBUTES_OID
-                                         = PKCS9_OIDS[9];
+            = PKCS9_OIDS[9];
     public static final ObjectIdentifier ISSUER_SERIALNUMBER_OID = PKCS9_OIDS[10];
     // [11], [12] are RSA DSI proprietary
     // [13] ==> signingDescription, S/MIME, not used anymore
@@ -216,7 +216,7 @@ public class PKCS9Attribute implements DerEncoder {
     public static final ObjectIdentifier SMIME_CAPABILITY_OID = PKCS9_OIDS[15];
     public static final ObjectIdentifier SIGNING_CERTIFICATE_OID = PKCS9_OIDS[16];
     public static final ObjectIdentifier SIGNATURE_TIMESTAMP_TOKEN_OID =
-                                PKCS9_OIDS[17];
+            PKCS9_OIDS[17];
     public static final String EMAIL_ADDRESS_STR = "EmailAddress";
     public static final String UNSTRUCTURED_NAME_STR = "UnstructuredName";
     public static final String CONTENT_TYPE_STR = "ContentType";
@@ -226,7 +226,7 @@ public class PKCS9Attribute implements DerEncoder {
     public static final String CHALLENGE_PASSWORD_STR = "ChallengePassword";
     public static final String UNSTRUCTURED_ADDRESS_STR = "UnstructuredAddress";
     public static final String EXTENDED_CERTIFICATE_ATTRIBUTES_STR =
-                               "ExtendedCertificateAttributes";
+            "ExtendedCertificateAttributes";
     public static final String ISSUER_SERIALNUMBER_STR = "IssuerAndSerialNumber";
     // [11], [12] are RSA DSI proprietary
     private static final String RSA_PROPRIETARY_STR = "RSAProprietary";
@@ -236,7 +236,7 @@ public class PKCS9Attribute implements DerEncoder {
     public static final String SMIME_CAPABILITY_STR = "SMIMECapability";
     public static final String SIGNING_CERTIFICATE_STR = "SigningCertificate";
     public static final String SIGNATURE_TIMESTAMP_TOKEN_STR =
-                                "SignatureTimestampToken";
+            "SignatureTimestampToken";
 
     /**
      * Hashtable mapping names and variant names of supported
@@ -244,7 +244,7 @@ public class PKCS9Attribute implements DerEncoder {
      * that occur in PKCS9, in lower case.
      */
     private static final Hashtable<String, ObjectIdentifier> NAME_OID_TABLE =
-        new Hashtable<String, ObjectIdentifier>(18);
+            new Hashtable<String, ObjectIdentifier>(18);
 
     static { // static initializer for PCKS9_NAMES
         NAME_OID_TABLE.put("emailaddress", PKCS9_OIDS[1]);
@@ -271,7 +271,7 @@ public class PKCS9Attribute implements DerEncoder {
      * corresponding attribute value type.
      */
     private static final Hashtable<ObjectIdentifier, String> OID_NAME_TABLE =
-        new Hashtable<ObjectIdentifier, String>(16);
+            new Hashtable<ObjectIdentifier, String>(16);
     static {
         OID_NAME_TABLE.put(PKCS9_OIDS[1], EMAIL_ADDRESS_STR);
         OID_NAME_TABLE.put(PKCS9_OIDS[2], UNSTRUCTURED_NAME_STR);
@@ -298,26 +298,26 @@ public class PKCS9Attribute implements DerEncoder {
      * Sets of acceptable tags are represented as arrays.
      */
     private static final Byte[][] PKCS9_VALUE_TAGS = {
-        null,
-        {new Byte(DerValue.tag_IA5String)},   // EMailAddress
-        {new Byte(DerValue.tag_IA5String)},   // UnstructuredName
-        {new Byte(DerValue.tag_ObjectId)},    // ContentType
-        {new Byte(DerValue.tag_OctetString)}, // MessageDigest
-        {new Byte(DerValue.tag_UtcTime)},     // SigningTime
-        {new Byte(DerValue.tag_Sequence)},    // Countersignature
-        {new Byte(DerValue.tag_PrintableString),
-         new Byte(DerValue.tag_T61String)},   // ChallengePassword
-        {new Byte(DerValue.tag_PrintableString),
-         new Byte(DerValue.tag_T61String)},   // UnstructuredAddress
-        {new Byte(DerValue.tag_SetOf)},       // ExtendedCertificateAttributes
-        {new Byte(DerValue.tag_Sequence)},    // issuerAndSerialNumber
-        null,
-        null,
-        null,
-        {new Byte(DerValue.tag_Sequence)},    // extensionRequest
-        {new Byte(DerValue.tag_Sequence)},    // SMIMECapability
-        {new Byte(DerValue.tag_Sequence)},    // SigningCertificate
-        {new Byte(DerValue.tag_Sequence)}     // SignatureTimestampToken
+            null,
+            {new Byte(DerValue.tag_IA5String)},   // EMailAddress
+            {new Byte(DerValue.tag_IA5String)},   // UnstructuredName
+            {new Byte(DerValue.tag_ObjectId)},    // ContentType
+            {new Byte(DerValue.tag_OctetString)}, // MessageDigest
+            {new Byte(DerValue.tag_UtcTime)},     // SigningTime
+            {new Byte(DerValue.tag_Sequence)},    // Countersignature
+            {new Byte(DerValue.tag_PrintableString),
+                    new Byte(DerValue.tag_T61String)},   // ChallengePassword
+            {new Byte(DerValue.tag_PrintableString),
+                    new Byte(DerValue.tag_T61String)},   // UnstructuredAddress
+            {new Byte(DerValue.tag_SetOf)},       // ExtendedCertificateAttributes
+            {new Byte(DerValue.tag_Sequence)},    // issuerAndSerialNumber
+            null,
+            null,
+            null,
+            {new Byte(DerValue.tag_Sequence)},    // extensionRequest
+            {new Byte(DerValue.tag_Sequence)},    // SMIMECapability
+            {new Byte(DerValue.tag_Sequence)},    // SigningCertificate
+            {new Byte(DerValue.tag_Sequence)}     // SignatureTimestampToken
     };
 
     private static final Class[] VALUE_CLASSES = new Class[18];
@@ -330,13 +330,13 @@ public class PKCS9Attribute implements DerEncoder {
             VALUE_CLASSES[1] = str;   // EMailAddress
             VALUE_CLASSES[2] = str;   // UnstructuredName
             VALUE_CLASSES[3] =        // ContentType
-                Class.forName("sun.security.util.ObjectIdentifier");
+                    Class.forName("sun.security.util.ObjectIdentifier");
             VALUE_CLASSES[4] = Class.forName("[B"); // MessageDigest (byte[])
             VALUE_CLASSES[5] = Class.forName("java.util.Date"); // SigningTime
             VALUE_CLASSES[6] =        // Countersignature
-                Class.forName("[Lsun.security.pkcs.SignerInfo;");
+                    Class.forName("[Lsun.security.pkcs.SignerInfo;");
             VALUE_CLASSES[7] =        // ChallengePassword
-                Class.forName("java.lang.String");
+                    Class.forName("java.lang.String");
             VALUE_CLASSES[8] = str;   // UnstructuredAddress
             VALUE_CLASSES[9] = null;  // ExtendedCertificateAttributes
             VALUE_CLASSES[10] = null;  // IssuerAndSerialNumber
@@ -344,7 +344,7 @@ public class PKCS9Attribute implements DerEncoder {
             VALUE_CLASSES[12] = null;  // not used
             VALUE_CLASSES[13] = null;  // not used
             VALUE_CLASSES[14] =        // ExtensionRequest
-                Class.forName("sun.security.x509.CertificateExtensions");
+                    Class.forName("sun.security.x509.CertificateExtensions");
             VALUE_CLASSES[15] = null;  // not supported yet
             VALUE_CLASSES[16] = null;  // not supported yet
             VALUE_CLASSES[17] = Class.forName("[B");  // SignatureTimestampToken
@@ -358,24 +358,24 @@ public class PKCS9Attribute implements DerEncoder {
      * by index in <code>PKCS9_OIDS</code>.
      */
     private static final boolean[] SINGLE_VALUED = {
-      false,
-      false,   // EMailAddress
-      false,   // UnstructuredName
-      true,    // ContentType
-      true,    // MessageDigest
-      true,    // SigningTime
-      false,   // Countersignature
-      true,    // ChallengePassword
-      false,   // UnstructuredAddress
-      false,   // ExtendedCertificateAttributes
-      true,    // IssuerAndSerialNumber - not supported yet
-      false,   // not used
-      false,   // not used
-      false,   // not used
-      true,    // ExtensionRequest
-      true,    // SMIMECapability - not supported yet
-      true,    // SigningCertificate
-      true     // SignatureTimestampToken
+            false,
+            false,   // EMailAddress
+            false,   // UnstructuredName
+            true,    // ContentType
+            true,    // MessageDigest
+            true,    // SigningTime
+            false,   // Countersignature
+            true,    // ChallengePassword
+            false,   // UnstructuredAddress
+            false,   // ExtendedCertificateAttributes
+            true,    // IssuerAndSerialNumber - not supported yet
+            false,   // not used
+            false,   // not used
+            false,   // not used
+            true,    // ExtensionRequest
+            true,    // SMIMECapability - not supported yet
+            true,    // SigningCertificate
+            true     // SignatureTimestampToken
     };
 
     /**
@@ -402,7 +402,7 @@ public class PKCS9Attribute implements DerEncoder {
      *
      */
     public PKCS9Attribute(ObjectIdentifier oid, Object value)
-    throws IllegalArgumentException {
+            throws IllegalArgumentException {
         init(oid, value);
     }
 
@@ -423,34 +423,34 @@ public class PKCS9Attribute implements DerEncoder {
      * <code>value</code> has the wrong type.
      */
     public PKCS9Attribute(String name, Object value)
-    throws IllegalArgumentException {
+            throws IllegalArgumentException {
         ObjectIdentifier oid = getOID(name);
 
         if (oid == null)
             throw new IllegalArgumentException(
-                       "Unrecognized attribute name " + name +
-                       " constructing PKCS9Attribute.");
+                    "Unrecognized attribute name " + name +
+                            " constructing PKCS9Attribute.");
 
         init(oid, value);
     }
 
     private void init(ObjectIdentifier oid, Object value)
-        throws IllegalArgumentException {
+            throws IllegalArgumentException {
 
         index = indexOf(oid, PKCS9_OIDS, 1);
 
         if (index == -1)
             throw new IllegalArgumentException(
-                       "Unsupported OID " + oid +
-                       " constructing PKCS9Attribute.");
+                    "Unsupported OID " + oid +
+                            " constructing PKCS9Attribute.");
 
         if (!VALUE_CLASSES[index].isInstance(value))
-                throw new IllegalArgumentException(
-                           "Wrong value class " +
-                           " for attribute " + oid +
-                           " constructing PKCS9Attribute; was " +
-                           value.getClass().toString() + ", should be " +
-                           VALUE_CLASSES[index].toString());
+            throw new IllegalArgumentException(
+                    "Wrong value class " +
+                            " for attribute " + oid +
+                            " constructing PKCS9Attribute; was " +
+                            value.getClass().toString() + ", should be " +
+                            VALUE_CLASSES[index].toString());
 
         this.value = value;
     }
@@ -460,7 +460,7 @@ public class PKCS9Attribute implements DerEncoder {
      * Construct a PKCS9Attribute from its encoding on an input
      * stream.
      *
-     * @param derVal the DerValue representing the DER encoding of the attribute.
+     * @param val the DerValue representing the DER encoding of the attribute.
      * @exception IOException on parsing error.
      */
     public PKCS9Attribute(DerValue derVal) throws IOException {
@@ -499,9 +499,9 @@ public class PKCS9Attribute implements DerEncoder {
         }
 
         switch (index) {
-        case 1:     // email address
-        case 2:     // unstructured name
-        case 8:     // unstructured address
+            case 1:     // email address
+            case 2:     // unstructured name
+            case 8:     // unstructured address
             { // open scope
                 String[] values = new String[elems.length];
 
@@ -511,66 +511,66 @@ public class PKCS9Attribute implements DerEncoder {
             } // close scope
             break;
 
-        case 3:     // content type
-            value = elems[0].getOID();
-            break;
+            case 3:     // content type
+                value = elems[0].getOID();
+                break;
 
-        case 4:     // message digest
-            value = elems[0].getOctetString();
-            break;
+            case 4:     // message digest
+                value = elems[0].getOctetString();
+                break;
 
-        case 5:     // signing time
-            value = (new DerInputStream(elems[0].toByteArray())).getUTCTime();
-            break;
+            case 5:     // signing time
+                value = (new DerInputStream(elems[0].toByteArray())).getUTCTime();
+                break;
 
-        case 6:     // countersignature
+            case 6:     // countersignature
             { // open scope
                 SignerInfo[] values = new SignerInfo[elems.length];
                 for (int i=0; i < elems.length; i++)
                     values[i] =
-                        new SignerInfo(elems[i].toDerInputStream());
+                            new SignerInfo(elems[i].toDerInputStream());
                 value = values;
             } // close scope
             break;
 
-        case 7:     // challenge password
-            value = elems[0].getAsString();
-            break;
+            case 7:     // challenge password
+                value = elems[0].getAsString();
+                break;
 
-        case 9:     // extended-certificate attribute -- not supported
-            throw new IOException("PKCS9 extended-certificate " +
-                                  "attribute not supported.");
-            // break unnecessary
-        case 10:    // issuerAndserialNumber attribute -- not supported
-            throw new IOException("PKCS9 IssuerAndSerialNumber" +
-                                  "attribute not supported.");
-            // break unnecessary
-        case 11:    // RSA DSI proprietary
-        case 12:    // RSA DSI proprietary
-            throw new IOException("PKCS9 RSA DSI attributes" +
-                                  "11 and 12, not supported.");
-            // break unnecessary
-        case 13:    // S/MIME unused attribute
-            throw new IOException("PKCS9 attribute #13 not supported.");
-            // break unnecessary
+            case 9:     // extended-certificate attribute -- not supported
+                throw new IOException("PKCS9 extended-certificate " +
+                        "attribute not supported.");
+                // break unnecessary
+            case 10:    // issuerAndserialNumber attribute -- not supported
+                throw new IOException("PKCS9 IssuerAndSerialNumber" +
+                        "attribute not supported.");
+                // break unnecessary
+            case 11:    // RSA DSI proprietary
+            case 12:    // RSA DSI proprietary
+                throw new IOException("PKCS9 RSA DSI attributes" +
+                        "11 and 12, not supported.");
+                // break unnecessary
+            case 13:    // S/MIME unused attribute
+                throw new IOException("PKCS9 attribute #13 not supported.");
+                // break unnecessary
 
-        case 14:     // ExtensionRequest
-            value = new CertificateExtensions(
-                       new DerInputStream(elems[0].toByteArray()));
-            break;
+            case 14:     // ExtensionRequest
+                value = new CertificateExtensions(
+                        new DerInputStream(elems[0].toByteArray()));
+                break;
 
-        case 15:     // SMIME-capability attribute -- not supported
-            throw new IOException("PKCS9 SMIMECapability " +
-                                  "attribute not supported.");
-            // break unnecessary
-        case 16:     // SigningCertificate attribute
-            value = new SigningCertificateInfo(elems[0].toByteArray());
-            break;
+            case 15:     // SMIME-capability attribute -- not supported
+                throw new IOException("PKCS9 SMIMECapability " +
+                        "attribute not supported.");
+                // break unnecessary
+            case 16:     // SigningCertificate attribute
+                value = new SigningCertificateInfo(elems[0].toByteArray());
+                break;
 
-        case 17:     // SignatureTimestampToken attribute
-            value = elems[0].toByteArray();
-            break;
-        default: // can't happen
+            case 17:     // SignatureTimestampToken attribute
+                value = elems[0].toByteArray();
+                break;
+            default: // can't happen
         }
     }
 
@@ -586,12 +586,12 @@ public class PKCS9Attribute implements DerEncoder {
         DerOutputStream temp = new DerOutputStream();
         temp.putOID(getOID());
         switch (index) {
-        case 1:     // email address
-        case 2:     // unstructured name
+            case 1:     // email address
+            case 2:     // unstructured name
             { // open scope
                 String[] values = (String[]) value;
                 DerOutputStream[] temps = new
-                    DerOutputStream[values.length];
+                        DerOutputStream[values.length];
 
                 for (int i=0; i < values.length; i++) {
                     temps[i] = new DerOutputStream();
@@ -601,7 +601,7 @@ public class PKCS9Attribute implements DerEncoder {
             } // close scope
             break;
 
-        case 3:     // content type
+            case 3:     // content type
             {
                 DerOutputStream temp2 = new DerOutputStream();
                 temp2.putOID((ObjectIdentifier) value);
@@ -609,7 +609,7 @@ public class PKCS9Attribute implements DerEncoder {
             }
             break;
 
-        case 4:     // message digest
+            case 4:     // message digest
             {
                 DerOutputStream temp2 = new DerOutputStream();
                 temp2.putOctetString((byte[]) value);
@@ -617,7 +617,7 @@ public class PKCS9Attribute implements DerEncoder {
             }
             break;
 
-        case 5:     // signing time
+            case 5:     // signing time
             {
                 DerOutputStream temp2 = new DerOutputStream();
                 temp2.putUTCTime((Date) value);
@@ -625,11 +625,11 @@ public class PKCS9Attribute implements DerEncoder {
             }
             break;
 
-        case 6:     // countersignature
-            temp.putOrderedSetOf(DerValue.tag_Set, (DerEncoder[]) value);
-            break;
+            case 6:     // countersignature
+                temp.putOrderedSetOf(DerValue.tag_Set, (DerEncoder[]) value);
+                break;
 
-        case 7:     // challenge password
+            case 7:     // challenge password
             {
                 DerOutputStream temp2 = new DerOutputStream();
                 temp2.putPrintableString((String) value);
@@ -637,11 +637,11 @@ public class PKCS9Attribute implements DerEncoder {
             }
             break;
 
-        case 8:     // unstructured address
+            case 8:     // unstructured address
             { // open scope
                 String[] values = (String[]) value;
                 DerOutputStream[] temps = new
-                    DerOutputStream[values.length];
+                        DerOutputStream[values.length];
 
                 for (int i=0; i < values.length; i++) {
                     temps[i] = new DerOutputStream();
@@ -651,24 +651,24 @@ public class PKCS9Attribute implements DerEncoder {
             } // close scope
             break;
 
-        case 9:     // extended-certificate attribute -- not supported
-            throw new IOException("PKCS9 extended-certificate " +
-                                  "attribute not supported.");
-            // break unnecessary
-        case 10:    // issuerAndserialNumber attribute -- not supported
-            throw new IOException("PKCS9 IssuerAndSerialNumber" +
-                                  "attribute not supported.");
-            // break unnecessary
-        case 11:    // RSA DSI proprietary
-        case 12:    // RSA DSI proprietary
-            throw new IOException("PKCS9 RSA DSI attributes" +
-                                  "11 and 12, not supported.");
-            // break unnecessary
-        case 13:    // S/MIME unused attribute
-            throw new IOException("PKCS9 attribute #13 not supported.");
-            // break unnecessary
+            case 9:     // extended-certificate attribute -- not supported
+                throw new IOException("PKCS9 extended-certificate " +
+                        "attribute not supported.");
+                // break unnecessary
+            case 10:    // issuerAndserialNumber attribute -- not supported
+                throw new IOException("PKCS9 IssuerAndSerialNumber" +
+                        "attribute not supported.");
+                // break unnecessary
+            case 11:    // RSA DSI proprietary
+            case 12:    // RSA DSI proprietary
+                throw new IOException("PKCS9 RSA DSI attributes" +
+                        "11 and 12, not supported.");
+                // break unnecessary
+            case 13:    // S/MIME unused attribute
+                throw new IOException("PKCS9 attribute #13 not supported.");
+                // break unnecessary
 
-        case 14:     // ExtensionRequest
+            case 14:     // ExtensionRequest
             {
                 DerOutputStream temp2 = new DerOutputStream();
                 CertificateExtensions exts = (CertificateExtensions)value;
@@ -680,20 +680,20 @@ public class PKCS9Attribute implements DerEncoder {
                 temp.write(DerValue.tag_Set, temp2.toByteArray());
             }
             break;
-        case 15:    // SMIMECapability
-            throw new IOException("PKCS9 attribute #15 not supported.");
-            // break unnecessary
+            case 15:    // SMIMECapability
+                throw new IOException("PKCS9 attribute #15 not supported.");
+                // break unnecessary
 
-        case 16:    // SigningCertificate
-            throw new IOException(
-                "PKCS9 SigningCertificate attribute not supported.");
-            // break unnecessary
+            case 16:    // SigningCertificate
+                throw new IOException(
+                        "PKCS9 SigningCertificate attribute not supported.");
+                // break unnecessary
 
-        case 17:    // SignatureTimestampToken
-            temp.write(DerValue.tag_Set, (byte[])value);
-            break;
+            case 17:    // SignatureTimestampToken
+                temp.write(DerValue.tag_Set, (byte[])value);
+                break;
 
-        default: // can't happen
+            default: // can't happen
         }
 
         DerOutputStream derOut = new DerOutputStream();
@@ -743,7 +743,7 @@ public class PKCS9Attribute implements DerEncoder {
      * the name.
      */
     public static ObjectIdentifier getOID(String name) {
-        return NAME_OID_TABLE.get(name.toLowerCase());
+        return NAME_OID_TABLE.get(name.toLowerCase(Locale.ENGLISH));
     }
 
     /**
@@ -809,8 +809,8 @@ public class PKCS9Attribute implements DerEncoder {
      */
     private void throwSingleValuedException() throws IOException {
         throw new IOException("Single-value attribute " +
-                              getOID() + " (" + getName() + ")" +
-                              " has multiple values.");
+                getOID() + " (" + getName() + ")" +
+                " has multiple values.");
     }
 
     /**
@@ -818,7 +818,7 @@ public class PKCS9Attribute implements DerEncoder {
      * wrong for the attribute whose value it is.
      */
     private void throwTagException(Byte tag)
-    throws IOException {
+            throws IOException {
         Byte[] expectedTags = PKCS9_VALUE_TAGS[index];
         StringBuffer msg = new StringBuffer(100);
         msg.append("Value of attribute ");

--- a/mas-foundation/src/main/java/sun/security/util/Debug.java
+++ b/mas-foundation/src/main/java/sun/security/util/Debug.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 1998-2007 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,16 +18,17 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package sun.security.util;
 
 import java.math.BigInteger;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.Locale;
 
 /**
  * A utility class for debuging.
@@ -43,17 +44,17 @@ public class Debug {
     static {
         args = java.security.AccessController.doPrivileged
                 (new sun.security.action.GetPropertyAction
-                ("java.security.debug"));
+                        ("java.security.debug"));
 
         String args2 = java.security.AccessController.doPrivileged
                 (new sun.security.action.GetPropertyAction
-                ("java.security.auth.debug"));
+                        ("java.security.auth.debug"));
 
         if (args == null) {
             args = args2;
         } else {
             if (args2 != null)
-               args = args + "," + args2;
+                args = args + "," + args2;
         }
 
         if (args != null) {
@@ -222,7 +223,7 @@ public class Debug {
             String keyReg = "[Pp][Ee][Rr][Mm][Ii][Ss][Ss][Ii][Oo][Nn]=";
             String keyStr = "permission=";
             String reg = keyReg +
-                "[a-zA-Z_$][a-zA-Z0-9_$]*([.][a-zA-Z_$][a-zA-Z0-9_$]*)*";
+                    "[a-zA-Z_$][a-zA-Z0-9_$]*([.][a-zA-Z_$][a-zA-Z0-9_$]*)*";
             Pattern pattern = Pattern.compile(reg);
             Matcher matcher = pattern.matcher(source);
             StringBuffer left = new StringBuffer();
@@ -262,7 +263,7 @@ public class Debug {
             source = left;
 
             // convert the rest to lower-case characters
-            target.append(source.toString().toLowerCase());
+            target.append(source.toString().toLowerCase(Locale.ENGLISH));
 
             return target.toString();
         }

--- a/mas-foundation/src/main/java/sun/security/x509/AlgorithmId.java
+++ b/mas-foundation/src/main/java/sun/security/x509/AlgorithmId.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 1996-2006 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 1996, 2010, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,29 +18,18 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package sun.security.x509;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.security.AlgorithmParameters;
-import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
-import java.security.Security;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.*;
+import java.util.*;
+import java.security.*;
 
-import sun.security.util.DerEncoder;
-import sun.security.util.DerInputStream;
-import sun.security.util.DerOutputStream;
-import sun.security.util.DerValue;
-import sun.security.util.ObjectIdentifier;
+import sun.security.util.*;
 
 
 /**
@@ -136,7 +125,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
                 // keys even if the provider is not registered.
                 // This code can go away once we have EC in the SUN provider.
                 algParams = AlgorithmParameters.getInstance(algidString,
-                                sun.security.ec.ECKeyFactory.ecInternalProvider);
+                        sun.security.ec.ECKeyFactory.ecInternalProvider);
             } catch (NoSuchAlgorithmException ee) {
                 /*
                  * This algorithm parameter type is not supported, so we cannot
@@ -283,7 +272,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      */
     public boolean equals(AlgorithmId other) {
         boolean paramsEqual =
-          (params == null ? other.params == null : params.equals(other.params));
+                (params == null ? other.params == null : params.equals(other.params));
         return (algid.equals(other.algid) && paramsEqual);
     }
 
@@ -420,12 +409,12 @@ public class AlgorithmId implements Serializable, DerEncoder {
             oid = algOID(algname);
         } catch (IOException ioe) {
             throw new NoSuchAlgorithmException
-                ("Invalid ObjectIdentifier " + algname);
+                    ("Invalid ObjectIdentifier " + algname);
         }
 
         if (oid == null) {
             throw new NoSuchAlgorithmException
-                ("unrecognized algorithm name: " + algname);
+                    ("unrecognized algorithm name: " + algname);
         }
         return new AlgorithmId(oid);
     }
@@ -445,11 +434,11 @@ public class AlgorithmId implements Serializable, DerEncoder {
             oid = algOID(algname);
         } catch (IOException ioe) {
             throw new NoSuchAlgorithmException
-                ("Invalid ObjectIdentifier " + algname);
+                    ("Invalid ObjectIdentifier " + algname);
         }
         if (oid == null) {
             throw new NoSuchAlgorithmException
-                ("unrecognized algorithm name: " + algname);
+                    ("unrecognized algorithm name: " + algname);
         }
         return new AlgorithmId(oid, algparams);
     }
@@ -484,19 +473,19 @@ public class AlgorithmId implements Serializable, DerEncoder {
             return AlgorithmId.MD2_oid;
         }
         if (name.equalsIgnoreCase("SHA") || name.equalsIgnoreCase("SHA1")
-            || name.equalsIgnoreCase("SHA-1")) {
+                || name.equalsIgnoreCase("SHA-1")) {
             return AlgorithmId.SHA_oid;
         }
         if (name.equalsIgnoreCase("SHA-256") ||
-            name.equalsIgnoreCase("SHA256")) {
+                name.equalsIgnoreCase("SHA256")) {
             return AlgorithmId.SHA256_oid;
         }
         if (name.equalsIgnoreCase("SHA-384") ||
-            name.equalsIgnoreCase("SHA384")) {
+                name.equalsIgnoreCase("SHA384")) {
             return AlgorithmId.SHA384_oid;
         }
         if (name.equalsIgnoreCase("SHA-512") ||
-            name.equalsIgnoreCase("SHA512")) {
+                name.equalsIgnoreCase("SHA512")) {
             return AlgorithmId.SHA512_oid;
         }
 
@@ -506,7 +495,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
             return AlgorithmId.RSAEncryption_oid;
         }
         if (name.equalsIgnoreCase("Diffie-Hellman")
-            || name.equalsIgnoreCase("DH")) {
+                || name.equalsIgnoreCase("DH")) {
             return AlgorithmId.DH_oid;
         }
         if (name.equalsIgnoreCase("DSA")) {
@@ -518,29 +507,41 @@ public class AlgorithmId implements Serializable, DerEncoder {
 
         // Common signature types
         if (name.equalsIgnoreCase("MD5withRSA")
-            || name.equalsIgnoreCase("MD5/RSA")) {
+                || name.equalsIgnoreCase("MD5/RSA")) {
             return AlgorithmId.md5WithRSAEncryption_oid;
         }
         if (name.equalsIgnoreCase("MD2withRSA")
-            || name.equalsIgnoreCase("MD2/RSA")) {
+                || name.equalsIgnoreCase("MD2/RSA")) {
             return AlgorithmId.md2WithRSAEncryption_oid;
         }
         if (name.equalsIgnoreCase("SHAwithDSA")
-            || name.equalsIgnoreCase("SHA1withDSA")
-            || name.equalsIgnoreCase("SHA/DSA")
-            || name.equalsIgnoreCase("SHA1/DSA")
-            || name.equalsIgnoreCase("DSAWithSHA1")
-            || name.equalsIgnoreCase("DSS")
-            || name.equalsIgnoreCase("SHA-1/DSA")) {
+                || name.equalsIgnoreCase("SHA1withDSA")
+                || name.equalsIgnoreCase("SHA/DSA")
+                || name.equalsIgnoreCase("SHA1/DSA")
+                || name.equalsIgnoreCase("DSAWithSHA1")
+                || name.equalsIgnoreCase("DSS")
+                || name.equalsIgnoreCase("SHA-1/DSA")) {
             return AlgorithmId.sha1WithDSA_oid;
         }
         if (name.equalsIgnoreCase("SHA1WithRSA")
-            || name.equalsIgnoreCase("SHA1/RSA")) {
+                || name.equalsIgnoreCase("SHA1/RSA")) {
             return AlgorithmId.sha1WithRSAEncryption_oid;
         }
         if (name.equalsIgnoreCase("SHA1withECDSA")
                 || name.equalsIgnoreCase("ECDSA")) {
             return AlgorithmId.sha1WithECDSA_oid;
+        }
+        if (name.equalsIgnoreCase("SHA224withECDSA")) {
+            return AlgorithmId.sha224WithECDSA_oid;
+        }
+        if (name.equalsIgnoreCase("SHA256withECDSA")) {
+            return AlgorithmId.sha256WithECDSA_oid;
+        }
+        if (name.equalsIgnoreCase("SHA384withECDSA")) {
+            return AlgorithmId.sha384WithECDSA_oid;
+        }
+        if (name.equalsIgnoreCase("SHA512withECDSA")) {
+            return AlgorithmId.sha512WithECDSA_oid;
         }
 
         // See if any of the installed providers supply a mapping from
@@ -552,9 +553,10 @@ public class AlgorithmId implements Serializable, DerEncoder {
                 for (Enumeration<Object> enum_ = provs[i].keys();
                      enum_.hasMoreElements(); ) {
                     String alias = (String)enum_.nextElement();
+                    String upperCaseAlias = alias.toUpperCase(Locale.ENGLISH);
                     int index;
-                    if (alias.toUpperCase().startsWith("ALG.ALIAS") &&
-                        (index=alias.toUpperCase().indexOf("OID.", 0)) != -1) {
+                    if (upperCaseAlias.startsWith("ALG.ALIAS") &&
+                            (index=upperCaseAlias.indexOf("OID.", 0)) != -1) {
                         index += "OID.".length();
                         if (index == alias.length()) {
                             // invalid alias entry
@@ -564,19 +566,26 @@ public class AlgorithmId implements Serializable, DerEncoder {
                             oidTable = new HashMap<String,ObjectIdentifier>();
                         }
                         oidString = alias.substring(index);
-                        String stdAlgName
-                            = provs[i].getProperty(alias).toUpperCase();
-                        if (oidTable.get(stdAlgName) == null) {
+                        String stdAlgName = provs[i].getProperty(alias);
+                        if (stdAlgName != null) {
+                            stdAlgName = stdAlgName.toUpperCase(Locale.ENGLISH);
+                        }
+                        if (stdAlgName != null &&
+                                oidTable.get(stdAlgName) == null) {
                             oidTable.put(stdAlgName,
-                                         new ObjectIdentifier(oidString));
+                                    new ObjectIdentifier(oidString));
                         }
                     }
                 }
             }
+
+            if (oidTable == null) {
+                oidTable = new HashMap<String,ObjectIdentifier>(1);
+            }
             initOidTable = true;
         }
 
-        return oidTable.get(name.toUpperCase());
+        return oidTable.get(name.toUpperCase(Locale.ENGLISH));
     }
 
     private static ObjectIdentifier oid(int ... values) {
@@ -598,14 +607,14 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.2.2
      */
     public static final ObjectIdentifier MD2_oid =
-    ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 2, 2});
+            ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 2, 2});
 
     /**
      * Algorithm ID for the MD5 Message Digest Algorthm, from RFC 1321.
      * OID = 1.2.840.113549.2.5
      */
     public static final ObjectIdentifier MD5_oid =
-    ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 2, 5});
+            ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 2, 5});
 
     /**
      * Algorithm ID for the SHA1 Message Digest Algorithm, from FIPS 180-1.
@@ -614,16 +623,16 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.3.14.3.2.26. Old SHA-0 OID: 1.3.14.3.2.18.
      */
     public static final ObjectIdentifier SHA_oid =
-    ObjectIdentifier.newInternal(new int[] {1, 3, 14, 3, 2, 26});
+            ObjectIdentifier.newInternal(new int[] {1, 3, 14, 3, 2, 26});
 
     public static final ObjectIdentifier SHA256_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 1});
+            ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 1});
 
     public static final ObjectIdentifier SHA384_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 2});
+            ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 2});
 
     public static final ObjectIdentifier SHA512_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 3});
+            ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 3});
 
     /*
      * COMMON PUBLIC KEY TYPES
@@ -632,9 +641,9 @@ public class AlgorithmId implements Serializable, DerEncoder {
     private static final int DH_PKIX_data[] = { 1, 2, 840, 10046, 2, 1 };
     private static final int DSA_OIW_data[] = { 1, 3, 14, 3, 2, 12 };
     private static final int DSA_PKIX_data[] = { 1, 2, 840, 10040, 4, 1 };
-    private static final int RSA_data[] = { 1, 2, 5, 8, 1, 1 };
+    private static final int RSA_data[] = { 2, 5, 8, 1, 1 };
     private static final int RSAEncryption_data[] =
-                                 { 1, 2, 840, 113549, 1, 1, 1 };
+            { 1, 2, 840, 113549, 1, 1, 1 };
 
     public static final ObjectIdentifier DH_oid;
     public static final ObjectIdentifier DH_PKIX_oid;
@@ -648,25 +657,25 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * COMMON SIGNATURE ALGORITHMS
      */
     private static final int md2WithRSAEncryption_data[] =
-                                       { 1, 2, 840, 113549, 1, 1, 2 };
+            { 1, 2, 840, 113549, 1, 1, 2 };
     private static final int md5WithRSAEncryption_data[] =
-                                       { 1, 2, 840, 113549, 1, 1, 4 };
+            { 1, 2, 840, 113549, 1, 1, 4 };
     private static final int sha1WithRSAEncryption_data[] =
-                                       { 1, 2, 840, 113549, 1, 1, 5 };
+            { 1, 2, 840, 113549, 1, 1, 5 };
     private static final int sha1WithRSAEncryption_OIW_data[] =
-                                       { 1, 3, 14, 3, 2, 29 };
+            { 1, 3, 14, 3, 2, 29 };
     private static final int sha256WithRSAEncryption_data[] =
-                                       { 1, 2, 840, 113549, 1, 1, 11 };
+            { 1, 2, 840, 113549, 1, 1, 11 };
     private static final int sha384WithRSAEncryption_data[] =
-                                       { 1, 2, 840, 113549, 1, 1, 12 };
+            { 1, 2, 840, 113549, 1, 1, 12 };
     private static final int sha512WithRSAEncryption_data[] =
-                                       { 1, 2, 840, 113549, 1, 1, 13 };
+            { 1, 2, 840, 113549, 1, 1, 13 };
     private static final int shaWithDSA_OIW_data[] =
-                                       { 1, 3, 14, 3, 2, 13 };
+            { 1, 3, 14, 3, 2, 13 };
     private static final int sha1WithDSA_OIW_data[] =
-                                       { 1, 3, 14, 3, 2, 27 };
+            { 1, 3, 14, 3, 2, 27 };
     private static final int dsaWithSHA1_PKIX_data[] =
-                                       { 1, 2, 840, 10040, 4, 3 };
+            { 1, 2, 840, 10040, 4, 3 };
 
     public static final ObjectIdentifier md2WithRSAEncryption_oid;
     public static final ObjectIdentifier md5WithRSAEncryption_oid;
@@ -680,170 +689,170 @@ public class AlgorithmId implements Serializable, DerEncoder {
     public static final ObjectIdentifier sha1WithDSA_oid;
 
     public static final ObjectIdentifier sha1WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 1);
+            oid(1, 2, 840, 10045, 4, 1);
     public static final ObjectIdentifier sha224WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 1);
+            oid(1, 2, 840, 10045, 4, 3, 1);
     public static final ObjectIdentifier sha256WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 2);
+            oid(1, 2, 840, 10045, 4, 3, 2);
     public static final ObjectIdentifier sha384WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 3);
+            oid(1, 2, 840, 10045, 4, 3, 3);
     public static final ObjectIdentifier sha512WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 4);
+            oid(1, 2, 840, 10045, 4, 3, 4);
     public static final ObjectIdentifier specifiedWithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3);
+            oid(1, 2, 840, 10045, 4, 3);
 
     /**
      * Algorithm ID for the PBE encryption algorithms from PKCS#5 and
      * PKCS#12.
      */
     public static final ObjectIdentifier pbeWithMD5AndDES_oid =
-        ObjectIdentifier.newInternal(new int[]{1, 2, 840, 113549, 1, 5, 3});
+            ObjectIdentifier.newInternal(new int[]{1, 2, 840, 113549, 1, 5, 3});
     public static final ObjectIdentifier pbeWithMD5AndRC2_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 6});
+            ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 6});
     public static final ObjectIdentifier pbeWithSHA1AndDES_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 10});
+            ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 10});
     public static final ObjectIdentifier pbeWithSHA1AndRC2_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 11});
+            ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 11});
     public static ObjectIdentifier pbeWithSHA1AndDESede_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 3});
+            ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 3});
     public static ObjectIdentifier pbeWithSHA1AndRC2_40_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 6});
+            ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 6});
 
 
     static {
-    /*
-     * Note the preferred OIDs are named simply with no "OIW" or
-     * "PKIX" in them, even though they may point to data from these
-     * specs; e.g. SHA_oid, DH_oid, DSA_oid, SHA1WithDSA_oid...
-     */
-    /**
-     * Algorithm ID for Diffie Hellman Key agreement, from PKCS #3.
-     * Parameters include public values P and G, and may optionally specify
-     * the length of the private key X.  Alternatively, algorithm parameters
-     * may be derived from another source such as a Certificate Authority's
-     * certificate.
-     * OID = 1.2.840.113549.1.3.1
-     */
+        /*
+         * Note the preferred OIDs are named simply with no "OIW" or
+         * "PKIX" in them, even though they may point to data from these
+         * specs; e.g. SHA_oid, DH_oid, DSA_oid, SHA1WithDSA_oid...
+         */
+        /**
+         * Algorithm ID for Diffie Hellman Key agreement, from PKCS #3.
+         * Parameters include public values P and G, and may optionally specify
+         * the length of the private key X.  Alternatively, algorithm parameters
+         * may be derived from another source such as a Certificate Authority's
+         * certificate.
+         * OID = 1.2.840.113549.1.3.1
+         */
         DH_oid = ObjectIdentifier.newInternal(DH_data);
 
-    /**
-     * Algorithm ID for the Diffie Hellman Key Agreement (DH), from RFC 3279.
-     * Parameters may include public values P and G.
-     * OID = 1.2.840.10046.2.1
-     */
+        /**
+         * Algorithm ID for the Diffie Hellman Key Agreement (DH), from RFC 3279.
+         * Parameters may include public values P and G.
+         * OID = 1.2.840.10046.2.1
+         */
         DH_PKIX_oid = ObjectIdentifier.newInternal(DH_PKIX_data);
 
-    /**
-     * Algorithm ID for the Digital Signing Algorithm (DSA), from the
-     * NIST OIW Stable Agreements part 12.
-     * Parameters may include public values P, Q, and G; or these may be
-     * derived from
-     * another source such as a Certificate Authority's certificate.
-     * OID = 1.3.14.3.2.12
-     */
+        /**
+         * Algorithm ID for the Digital Signing Algorithm (DSA), from the
+         * NIST OIW Stable Agreements part 12.
+         * Parameters may include public values P, Q, and G; or these may be
+         * derived from
+         * another source such as a Certificate Authority's certificate.
+         * OID = 1.3.14.3.2.12
+         */
         DSA_OIW_oid = ObjectIdentifier.newInternal(DSA_OIW_data);
 
-    /**
-     * Algorithm ID for the Digital Signing Algorithm (DSA), from RFC 3279.
-     * Parameters may include public values P, Q, and G; or these may be
-     * derived from another source such as a Certificate Authority's
-     * certificate.
-     * OID = 1.2.840.10040.4.1
-     */
+        /**
+         * Algorithm ID for the Digital Signing Algorithm (DSA), from RFC 3279.
+         * Parameters may include public values P, Q, and G; or these may be
+         * derived from another source such as a Certificate Authority's
+         * certificate.
+         * OID = 1.2.840.10040.4.1
+         */
         DSA_oid = ObjectIdentifier.newInternal(DSA_PKIX_data);
 
-    /**
-     * Algorithm ID for RSA keys used for any purpose, as defined in X.509.
-     * The algorithm parameter is a single value, the number of bits in the
-     * public modulus.
-     * OID = 1.2.5.8.1.1
-     */
+        /**
+         * Algorithm ID for RSA keys used for any purpose, as defined in X.509.
+         * The algorithm parameter is a single value, the number of bits in the
+         * public modulus.
+         * OID = 2.5.8.1.1
+         */
         RSA_oid = ObjectIdentifier.newInternal(RSA_data);
 
-    /**
-     * Algorithm ID for RSA keys used with RSA encryption, as defined
-     * in PKCS #1.  There are no parameters associated with this algorithm.
-     * OID = 1.2.840.113549.1.1.1
-     */
+        /**
+         * Algorithm ID for RSA keys used with RSA encryption, as defined
+         * in PKCS #1.  There are no parameters associated with this algorithm.
+         * OID = 1.2.840.113549.1.1.1
+         */
         RSAEncryption_oid = ObjectIdentifier.newInternal(RSAEncryption_data);
 
-    /**
-     * Identifies a signing algorithm where an MD2 digest is encrypted
-     * using an RSA private key; defined in PKCS #1.  Use of this
-     * signing algorithm is discouraged due to MD2 vulnerabilities.
-     * OID = 1.2.840.113549.1.1.2
-     */
+        /**
+         * Identifies a signing algorithm where an MD2 digest is encrypted
+         * using an RSA private key; defined in PKCS #1.  Use of this
+         * signing algorithm is discouraged due to MD2 vulnerabilities.
+         * OID = 1.2.840.113549.1.1.2
+         */
         md2WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(md2WithRSAEncryption_data);
+                ObjectIdentifier.newInternal(md2WithRSAEncryption_data);
 
-    /**
-     * Identifies a signing algorithm where an MD5 digest is
-     * encrypted using an RSA private key; defined in PKCS #1.
-     * OID = 1.2.840.113549.1.1.4
-     */
+        /**
+         * Identifies a signing algorithm where an MD5 digest is
+         * encrypted using an RSA private key; defined in PKCS #1.
+         * OID = 1.2.840.113549.1.1.4
+         */
         md5WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(md5WithRSAEncryption_data);
+                ObjectIdentifier.newInternal(md5WithRSAEncryption_data);
 
-    /**
-     * Identifies a signing algorithm where a SHA1 digest is
-     * encrypted using an RSA private key; defined by RSA DSI.
-     * OID = 1.2.840.113549.1.1.5
-     */
+        /**
+         * Identifies a signing algorithm where a SHA1 digest is
+         * encrypted using an RSA private key; defined by RSA DSI.
+         * OID = 1.2.840.113549.1.1.5
+         */
         sha1WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha1WithRSAEncryption_data);
+                ObjectIdentifier.newInternal(sha1WithRSAEncryption_data);
 
-    /**
-     * Identifies a signing algorithm where a SHA1 digest is
-     * encrypted using an RSA private key; defined in NIST OIW.
-     * OID = 1.3.14.3.2.29
-     */
+        /**
+         * Identifies a signing algorithm where a SHA1 digest is
+         * encrypted using an RSA private key; defined in NIST OIW.
+         * OID = 1.3.14.3.2.29
+         */
         sha1WithRSAEncryption_OIW_oid =
-            ObjectIdentifier.newInternal(sha1WithRSAEncryption_OIW_data);
+                ObjectIdentifier.newInternal(sha1WithRSAEncryption_OIW_data);
 
-    /**
-     * Identifies a signing algorithm where a SHA256 digest is
-     * encrypted using an RSA private key; defined by PKCS #1.
-     * OID = 1.2.840.113549.1.1.11
-     */
+        /**
+         * Identifies a signing algorithm where a SHA256 digest is
+         * encrypted using an RSA private key; defined by PKCS #1.
+         * OID = 1.2.840.113549.1.1.11
+         */
         sha256WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha256WithRSAEncryption_data);
+                ObjectIdentifier.newInternal(sha256WithRSAEncryption_data);
 
-    /**
-     * Identifies a signing algorithm where a SHA384 digest is
-     * encrypted using an RSA private key; defined by PKCS #1.
-     * OID = 1.2.840.113549.1.1.12
-     */
+        /**
+         * Identifies a signing algorithm where a SHA384 digest is
+         * encrypted using an RSA private key; defined by PKCS #1.
+         * OID = 1.2.840.113549.1.1.12
+         */
         sha384WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha384WithRSAEncryption_data);
+                ObjectIdentifier.newInternal(sha384WithRSAEncryption_data);
 
-    /**
-     * Identifies a signing algorithm where a SHA512 digest is
-     * encrypted using an RSA private key; defined by PKCS #1.
-     * OID = 1.2.840.113549.1.1.13
-     */
+        /**
+         * Identifies a signing algorithm where a SHA512 digest is
+         * encrypted using an RSA private key; defined by PKCS #1.
+         * OID = 1.2.840.113549.1.1.13
+         */
         sha512WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha512WithRSAEncryption_data);
+                ObjectIdentifier.newInternal(sha512WithRSAEncryption_data);
 
-    /**
-     * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
-     * SHA digest is signed using the Digital Signing Algorithm (DSA).
-     * This should not be used.
-     * OID = 1.3.14.3.2.13
-     */
+        /**
+         * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
+         * SHA digest is signed using the Digital Signing Algorithm (DSA).
+         * This should not be used.
+         * OID = 1.3.14.3.2.13
+         */
         shaWithDSA_OIW_oid = ObjectIdentifier.newInternal(shaWithDSA_OIW_data);
 
-    /**
-     * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
-     * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
-     * OID = 1.3.14.3.2.27
-     */
+        /**
+         * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
+         * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
+         * OID = 1.3.14.3.2.27
+         */
         sha1WithDSA_OIW_oid = ObjectIdentifier.newInternal(sha1WithDSA_OIW_data);
 
-    /**
-     * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
-     * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
-     * OID = 1.2.840.10040.4.3
-     */
+        /**
+         * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
+         * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
+         * OID = 1.2.840.10040.4.3
+         */
         sha1WithDSA_oid = ObjectIdentifier.newInternal(dsaWithSHA1_PKIX_data);
 
         nameTable = new HashMap<ObjectIdentifier,String>();
@@ -881,5 +890,54 @@ public class AlgorithmId implements Serializable, DerEncoder {
         nameTable.put(pbeWithSHA1AndRC2_oid, "PBEWithSHA1AndRC2");
         nameTable.put(pbeWithSHA1AndDESede_oid, "PBEWithSHA1AndDESede");
         nameTable.put(pbeWithSHA1AndRC2_40_oid, "PBEWithSHA1AndRC2_40");
+    }
+
+    /**
+     * Creates a signature algorithm name from a digest algorithm
+     * name and a encryption algorithm name.
+     */
+    public static String makeSigAlg(String digAlg, String encAlg) {
+        digAlg = digAlg.replace("-", "").toUpperCase(Locale.ENGLISH);
+        if (digAlg.equalsIgnoreCase("SHA")) digAlg = "SHA1";
+
+        encAlg = encAlg.toUpperCase(Locale.ENGLISH);
+        if (encAlg.equals("EC")) encAlg = "ECDSA";
+
+        return digAlg + "with" + encAlg;
+    }
+
+    /**
+     * Extracts the encryption algorithm name from a signature
+     * algorithm name.
+     */
+    public static String getEncAlgFromSigAlg(String signatureAlgorithm) {
+        signatureAlgorithm = signatureAlgorithm.toUpperCase(Locale.ENGLISH);
+        int with = signatureAlgorithm.indexOf("WITH");
+        String keyAlgorithm = null;
+        if (with > 0) {
+            int and = signatureAlgorithm.indexOf("AND", with + 4);
+            if (and > 0) {
+                keyAlgorithm = signatureAlgorithm.substring(with + 4, and);
+            } else {
+                keyAlgorithm = signatureAlgorithm.substring(with + 4);
+            }
+            if (keyAlgorithm.equalsIgnoreCase("ECDSA")) {
+                keyAlgorithm = "EC";
+            }
+        }
+        return keyAlgorithm;
+    }
+
+    /**
+     * Extracts the digest algorithm name from a signature
+     * algorithm name.
+     */
+    public static String getDigAlgFromSigAlg(String signatureAlgorithm) {
+        signatureAlgorithm = signatureAlgorithm.toUpperCase(Locale.ENGLISH);
+        int with = signatureAlgorithm.indexOf("WITH");
+        if (with > 0) {
+            return signatureAlgorithm.substring(0, with);
+        }
+        return null;
     }
 }

--- a/mas-foundation/src/main/java/sun/security/x509/DNSName.java
+++ b/mas-foundation/src/main/java/sun/security/x509/DNSName.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 1997-2000 Sun Microsystems, Inc.  All Rights Reserved.
+ * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Sun designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Sun in the LICENSE file that accompanied this code.
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -18,17 +18,17 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
- * CA 95054 USA or visit www.sun.com if you need additional information or
- * have any questions.
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 package sun.security.x509;
 
 import java.io.IOException;
+import java.util.Locale;
 
-import sun.security.util.DerOutputStream;
-import sun.security.util.DerValue;
+import sun.security.util.*;
 
 /**
  * This class implements the DNSName as required by the GeneralNames
@@ -188,7 +188,7 @@ public class DNSName implements GeneralNameInterface {
      * order zero bit.
      * <p>
      * @param inputName to be checked for being constrained
-     * @return constraint type above
+     * @returns constraint type above
      * @throws UnsupportedOperationException if name is not exact match, but narrowing and widening are
      *          not supported for this name type.
      */
@@ -199,8 +199,9 @@ public class DNSName implements GeneralNameInterface {
         else if (inputName.getType() != NAME_DNS)
             constraintType = NAME_DIFF_TYPE;
         else {
-            String inName = (((DNSName)inputName).getName()).toLowerCase();
-            String thisName = name.toLowerCase();
+            String inName =
+                    (((DNSName)inputName).getName()).toLowerCase(Locale.ENGLISH);
+            String thisName = name.toLowerCase(Locale.ENGLISH);
             if (inName.equals(thisName))
                 constraintType = NAME_MATCH;
             else if (thisName.endsWith(inName)) {
@@ -227,7 +228,7 @@ public class DNSName implements GeneralNameInterface {
      * NameConstraints minimum and maximum bounds and for calculating
      * path lengths in name subtrees.
      *
-     * @return distance of name from root
+     * @returns distance of name from root
      * @throws UnsupportedOperationException if not supported for this name type
      */
     public int subtreeDepth() throws UnsupportedOperationException {

--- a/mas-foundation/src/main/java/sun/security/x509/RFC822Name.java
+++ b/mas-foundation/src/main/java/sun/security/x509/RFC822Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,9 @@
 package sun.security.x509;
 
 import java.io.IOException;
+import java.util.Locale;
 
-import sun.security.util.DerOutputStream;
-import sun.security.util.DerValue;
+import sun.security.util.*;
 
 /**
  * This class implements the RFC822Name as required by the GeneralNames
@@ -176,7 +176,7 @@ public class RFC822Name implements GeneralNameInterface
      * RFC 822 addr-spec, no significance is attached to the case.
      * <p>
      * @param inputName to be checked for being constrained
-     * @return constraint type above
+     * @returns constraint type above
      * @throws UnsupportedOperationException if name is not exact match, but narrowing and widening are
      *          not supported for this name type.
      */
@@ -188,8 +188,9 @@ public class RFC822Name implements GeneralNameInterface
             constraintType = NAME_DIFF_TYPE;
         } else {
             //RFC2459 specifies that case is not significant in RFC822Names
-            String inName = (((RFC822Name)inputName).getName()).toLowerCase();
-            String thisName = name.toLowerCase();
+            String inName =
+                    (((RFC822Name)inputName).getName()).toLowerCase(Locale.ENGLISH);
+            String thisName = name.toLowerCase(Locale.ENGLISH);
             if (inName.equals(thisName)) {
                 constraintType = NAME_MATCH;
             } else if (thisName.endsWith(inName)) {
@@ -231,7 +232,7 @@ public class RFC822Name implements GeneralNameInterface
      * Return subtree depth of this name for purposes of determining
      * NameConstraints minimum and maximum bounds.
      *
-     * @return distance of name from root
+     * @returns distance of name from root
      * @throws UnsupportedOperationException if not supported for this name type
      */
     public int subtreeDepth() throws UnsupportedOperationException {


### PR DESCRIPTION
The issue is caused by the Sun library which is part of the MAS library. The error happens with a specific Turkish language and if AlgorithmId class is obfuscated as part of the MMM application obfuscation. The defect causes a NullPointerException which prevents login from completing.

We have the fix already here:
https://hg.openjdk.java.net/jdk7/jdk7/jdk/rev/56217857ccd7

We took the changes and used the same fix present in the change set.