### PR TITLE
SSL pinning disable implementation

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
@@ -310,6 +310,7 @@ public interface MobileSsoConfig {
     String PROP_DEVICE_METADATA_PATH = "msso_device_metadata";
 
 
+    String PROP_SSL_PINNING_ENABLED = "ssl_pinning_enabled";
     // If you add any properties to this file, you must update MobileSsoFactory.createConfig()
     // or they will be ignored.
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
@@ -255,7 +255,7 @@ public interface MobileSsoConfig {
      *
      * True if MSISDN information should be included.  False if MSISDN information should not be included.
      */
-     String PROP_MSISDN_ENABLED = "msso.msisdn.enabled";
+    String PROP_MSISDN_ENABLED = "msso.msisdn.enabled";
 
     /**
      * String.  URL suffix for client credentials endpoint.
@@ -310,6 +310,7 @@ public interface MobileSsoConfig {
     String PROP_DEVICE_METADATA_PATH = "msso_device_metadata";
 
 
+    String PROP_SSL_PINNING_ENABLED = "ssl_pinning_enabled";
     // If you add any properties to this file, you must update MobileSsoFactory.createConfig()
     // or they will be ignored.
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
@@ -310,7 +310,7 @@ public interface MobileSsoConfig {
     String PROP_DEVICE_METADATA_PATH = "msso_device_metadata";
 
 
-    String PROP_SSL_PINNING_ENABLED = "ssl_pinning_enabled";
+    String PROP_ALLOW_SSL_PINNING = "allow_ssl_pinning";
     // If you add any properties to this file, you must update MobileSsoFactory.createConfig()
     // or they will be ignored.
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/MobileSsoConfig.java
@@ -310,7 +310,6 @@ public interface MobileSsoConfig {
     String PROP_DEVICE_METADATA_PATH = "msso_device_metadata";
 
 
-    String PROP_SSL_PINNING_ENABLED = "ssl_pinning_enabled";
     // If you add any properties to this file, you must update MobileSsoFactory.createConfig()
     // or they will be ignored.
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
@@ -56,7 +56,7 @@ public class Config {
     public static final Config TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES = new Config(false, MobileSsoConfig.PROP_TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES, "mag.mobile_sdk.trusted_cert_pinned_public_key_hashes", List.class);
     public static final Config CLIENT_CERT_RSA_KEYBITS = new Config(false, MobileSsoConfig.PROP_CLIENT_CERT_RSA_KEYBITS, "mag.mobile_sdk.client_cert_rsa_keybits", Integer.class);
     public static final Config CLIENT_STORAGE = new Config(false, MobileSsoConfig.PROP_STORAGE, "mag.mobile_sdk.storage", String.class);
-    public static final Config SSL_PINNING_ENABLED = new Config(false, MobileSsoConfig.PROP_SSL_PINNING_ENABLED, "mag.mobile_sdk.ssl_pinning_enabled", Boolean.class);
+    public static final Config ALLOW_SSL_PINNING = new Config(false, MobileSsoConfig.PROP_ALLOW_SSL_PINNING, "mag.mobile_sdk.allow_ssl_pinning", Boolean.class);
 
     //mag.ble
     public static final Config BLE_SERVICE_UUID = new Config(false, MobileSsoConfig.PROP_BLE_SERVICE_UUID, "mag.ble.msso_ble_service_uuid", String.class);
@@ -67,7 +67,7 @@ public class Config {
             HOSTNAME, PORT, PREFIX, SERVER_CERTS, ORGANIZATION, CLIENT_KEY, CLIENT_SECRET, SCOPE, REDIRECT_URI, AUTHORIZE_PATH, REGISTER_TOKEN_PATH, REGISTER_TOKEN_PATH_SSO, LOGOUT_DEVICE_PATH, REVOKE_PATH,
             REMOVE_DEVICE_PATH, REGISTER_DEVICE_PATH, RENEW_DEVICE_PATH, REGISTER_DEVICE_PATH_CLIENT, CLIENT_CREDENTIAL_INIT_PATH, ENTERPRISE_APP_PATH, SSO_ENABLED, LOCATION_ENABLED, LOCATION_PROVIDER,
             MSISDN_ENABLED, TRUSTED_PUBLIC_PKI,DEVICE_METADATA_PATH, TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES, CLIENT_CERT_RSA_KEYBITS, CLIENT_STORAGE, BLE_SERVICE_UUID, BLE_USER_SESSION_CHARACTERISTIC_UUID,
-            BLE_RSSI, AUTHENTICATE_OTP_PATH, SSL_PINNING_ENABLED
+            BLE_RSSI, AUTHENTICATE_OTP_PATH, ALLOW_SSL_PINNING
     };
 
     public boolean mandatory;

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
@@ -56,7 +56,7 @@ public class Config {
     public static final Config TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES = new Config(false, MobileSsoConfig.PROP_TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES, "mag.mobile_sdk.trusted_cert_pinned_public_key_hashes", List.class);
     public static final Config CLIENT_CERT_RSA_KEYBITS = new Config(false, MobileSsoConfig.PROP_CLIENT_CERT_RSA_KEYBITS, "mag.mobile_sdk.client_cert_rsa_keybits", Integer.class);
     public static final Config CLIENT_STORAGE = new Config(false, MobileSsoConfig.PROP_STORAGE, "mag.mobile_sdk.storage", String.class);
-    public static final Config SSL_PINNING_ENABLED = new Config(true, MobileSsoConfig.PROP_SSL_PINNING_ENABLED, "mag.mobile_sdk.ssl_pinning_enabled", Boolean.class);
+    public static final Config SSL_PINNING_ENABLED = new Config(false, MobileSsoConfig.PROP_SSL_PINNING_ENABLED, "mag.mobile_sdk.ssl_pinning_enabled", Boolean.class);
 
     //mag.ble
     public static final Config BLE_SERVICE_UUID = new Config(false, MobileSsoConfig.PROP_BLE_SERVICE_UUID, "mag.ble.msso_ble_service_uuid", String.class);

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
@@ -56,7 +56,6 @@ public class Config {
     public static final Config TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES = new Config(false, MobileSsoConfig.PROP_TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES, "mag.mobile_sdk.trusted_cert_pinned_public_key_hashes", List.class);
     public static final Config CLIENT_CERT_RSA_KEYBITS = new Config(false, MobileSsoConfig.PROP_CLIENT_CERT_RSA_KEYBITS, "mag.mobile_sdk.client_cert_rsa_keybits", Integer.class);
     public static final Config CLIENT_STORAGE = new Config(false, MobileSsoConfig.PROP_STORAGE, "mag.mobile_sdk.storage", String.class);
-    public static final Config SSL_PINNING_ENABLED = new Config(true, MobileSsoConfig.PROP_SSL_PINNING_ENABLED, "mag.mobile_sdk.ssl_pinning_enabled", Boolean.class);
 
     //mag.ble
     public static final Config BLE_SERVICE_UUID = new Config(false, MobileSsoConfig.PROP_BLE_SERVICE_UUID, "mag.ble.msso_ble_service_uuid", String.class);
@@ -67,7 +66,7 @@ public class Config {
             HOSTNAME, PORT, PREFIX, SERVER_CERTS, ORGANIZATION, CLIENT_KEY, CLIENT_SECRET, SCOPE, REDIRECT_URI, AUTHORIZE_PATH, REGISTER_TOKEN_PATH, REGISTER_TOKEN_PATH_SSO, LOGOUT_DEVICE_PATH, REVOKE_PATH,
             REMOVE_DEVICE_PATH, REGISTER_DEVICE_PATH, RENEW_DEVICE_PATH, REGISTER_DEVICE_PATH_CLIENT, CLIENT_CREDENTIAL_INIT_PATH, ENTERPRISE_APP_PATH, SSO_ENABLED, LOCATION_ENABLED, LOCATION_PROVIDER,
             MSISDN_ENABLED, TRUSTED_PUBLIC_PKI,DEVICE_METADATA_PATH, TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES, CLIENT_CERT_RSA_KEYBITS, CLIENT_STORAGE, BLE_SERVICE_UUID, BLE_USER_SESSION_CHARACTERISTIC_UUID,
-            BLE_RSSI, AUTHENTICATE_OTP_PATH, SSL_PINNING_ENABLED
+            BLE_RSSI, AUTHENTICATE_OTP_PATH
     };
 
     public boolean mandatory;

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/Config.java
@@ -56,6 +56,7 @@ public class Config {
     public static final Config TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES = new Config(false, MobileSsoConfig.PROP_TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES, "mag.mobile_sdk.trusted_cert_pinned_public_key_hashes", List.class);
     public static final Config CLIENT_CERT_RSA_KEYBITS = new Config(false, MobileSsoConfig.PROP_CLIENT_CERT_RSA_KEYBITS, "mag.mobile_sdk.client_cert_rsa_keybits", Integer.class);
     public static final Config CLIENT_STORAGE = new Config(false, MobileSsoConfig.PROP_STORAGE, "mag.mobile_sdk.storage", String.class);
+    public static final Config SSL_PINNING_ENABLED = new Config(true, MobileSsoConfig.PROP_SSL_PINNING_ENABLED, "mag.mobile_sdk.ssl_pinning_enabled", Boolean.class);
 
     //mag.ble
     public static final Config BLE_SERVICE_UUID = new Config(false, MobileSsoConfig.PROP_BLE_SERVICE_UUID, "mag.ble.msso_ble_service_uuid", String.class);
@@ -66,7 +67,7 @@ public class Config {
             HOSTNAME, PORT, PREFIX, SERVER_CERTS, ORGANIZATION, CLIENT_KEY, CLIENT_SECRET, SCOPE, REDIRECT_URI, AUTHORIZE_PATH, REGISTER_TOKEN_PATH, REGISTER_TOKEN_PATH_SSO, LOGOUT_DEVICE_PATH, REVOKE_PATH,
             REMOVE_DEVICE_PATH, REGISTER_DEVICE_PATH, RENEW_DEVICE_PATH, REGISTER_DEVICE_PATH_CLIENT, CLIENT_CREDENTIAL_INIT_PATH, ENTERPRISE_APP_PATH, SSO_ENABLED, LOCATION_ENABLED, LOCATION_PROVIDER,
             MSISDN_ENABLED, TRUSTED_PUBLIC_PKI,DEVICE_METADATA_PATH, TRUSTED_CERT_PINNED_PUBLIC_KEY_HASHES, CLIENT_CERT_RSA_KEYBITS, CLIENT_STORAGE, BLE_SERVICE_UUID, BLE_USER_SESSION_CHARACTERISTIC_UUID,
-            BLE_RSSI, AUTHENTICATE_OTP_PATH
+            BLE_RSSI, AUTHENTICATE_OTP_PATH, SSL_PINNING_ENABLED
     };
 
     public boolean mandatory;

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
@@ -46,7 +46,7 @@ public class ConfigurationManager {
     private List<Config> appConfigs;
     private String configurationFileName = null;
     private boolean enablePKCE = true;
-    private boolean enableSslPinning = false;
+    private boolean enableSslPinning = true;
     private boolean idTokenValidation = true;
     private boolean enableJwksPreload = false;
     private JSONObject jsonConfiguration;
@@ -269,7 +269,7 @@ public class ConfigurationManager {
             }
 
             if (attr == Config.SSL_PINNING_ENABLED) {
-                conf.setAlsoTrustPublicPki((Boolean) getValue(Config.TRUSTED_PUBLIC_PKI, jsonObject, Boolean.FALSE));
+                conf.setAllowSSLPinning((Boolean) getValue(Config.SSL_PINNING_ENABLED, jsonObject, Boolean.TRUE));
                 continue;
             }
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
@@ -46,7 +46,6 @@ public class ConfigurationManager {
     private List<Config> appConfigs;
     private String configurationFileName = null;
     private boolean enablePKCE = true;
-    private boolean enableSslPinning = false;
     private boolean idTokenValidation = true;
     private boolean enableJwksPreload = false;
     private JSONObject jsonConfiguration;
@@ -79,10 +78,6 @@ public class ConfigurationManager {
         this.enablePKCE = enablePKCE;
     }
 
-    public void enableSslPinningEnabled(boolean enableSslPinning) {
-        this.enableSslPinning = enableSslPinning;
-    }
-
     public void enableIdTokenValidation(boolean enableValidation) {
         this.idTokenValidation = enableValidation;
     }
@@ -93,10 +88,6 @@ public class ConfigurationManager {
 
     public boolean isPKCEEnabled() {
         return enablePKCE;
-    }
-
-    public boolean isSslPinningEnabled() {
-        return enableSslPinning;
     }
 
     public void reset() {
@@ -267,12 +258,6 @@ public class ConfigurationManager {
                 conf.setAlsoTrustPublicPki((Boolean) getValue(Config.TRUSTED_PUBLIC_PKI, jsonObject, Boolean.FALSE));
                 continue;
             }
-
-            if (attr == Config.SSL_PINNING_ENABLED) {
-                conf.setAlsoTrustPublicPki((Boolean) getValue(Config.TRUSTED_PUBLIC_PKI, jsonObject, Boolean.FALSE));
-                continue;
-            }
-
             Object value = getValue(attr, jsonObject);
             if (value != null) {
                 conf.putProperty(attr.key, value);

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
@@ -46,7 +46,7 @@ public class ConfigurationManager {
     private List<Config> appConfigs;
     private String configurationFileName = null;
     private boolean enablePKCE = true;
-    private boolean enableSslPinning = true;
+    private boolean sslPinningEnabled = true;
     private boolean idTokenValidation = true;
     private boolean enableJwksPreload = false;
     private JSONObject jsonConfiguration;
@@ -79,8 +79,8 @@ public class ConfigurationManager {
         this.enablePKCE = enablePKCE;
     }
 
-    public void enableSslPinningEnabled(boolean enableSslPinning) {
-        this.enableSslPinning = enableSslPinning;
+    public void setSSLPinningEnabled(boolean enable) {
+        this.sslPinningEnabled = enable;
     }
 
     public void enableIdTokenValidation(boolean enableValidation) {
@@ -96,7 +96,7 @@ public class ConfigurationManager {
     }
 
     public boolean isSslPinningEnabled() {
-        return enableSslPinning;
+        return sslPinningEnabled;
     }
 
     public void reset() {
@@ -268,8 +268,8 @@ public class ConfigurationManager {
                 continue;
             }
 
-            if (attr == Config.SSL_PINNING_ENABLED) {
-                conf.setAllowSSLPinning((Boolean) getValue(Config.SSL_PINNING_ENABLED, jsonObject, Boolean.TRUE));
+            if (attr == Config.ALLOW_SSL_PINNING) {
+                conf.setAllowSSLPinning((Boolean) getValue(Config.ALLOW_SSL_PINNING, jsonObject, Boolean.TRUE));
                 continue;
             }
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationManager.java
@@ -46,6 +46,7 @@ public class ConfigurationManager {
     private List<Config> appConfigs;
     private String configurationFileName = null;
     private boolean enablePKCE = true;
+    private boolean enableSslPinning = false;
     private boolean idTokenValidation = true;
     private boolean enableJwksPreload = false;
     private JSONObject jsonConfiguration;
@@ -78,6 +79,10 @@ public class ConfigurationManager {
         this.enablePKCE = enablePKCE;
     }
 
+    public void enableSslPinningEnabled(boolean enableSslPinning) {
+        this.enableSslPinning = enableSslPinning;
+    }
+
     public void enableIdTokenValidation(boolean enableValidation) {
         this.idTokenValidation = enableValidation;
     }
@@ -88,6 +93,10 @@ public class ConfigurationManager {
 
     public boolean isPKCEEnabled() {
         return enablePKCE;
+    }
+
+    public boolean isSslPinningEnabled() {
+        return enableSslPinning;
     }
 
     public void reset() {
@@ -258,6 +267,12 @@ public class ConfigurationManager {
                 conf.setAlsoTrustPublicPki((Boolean) getValue(Config.TRUSTED_PUBLIC_PKI, jsonObject, Boolean.FALSE));
                 continue;
             }
+
+            if (attr == Config.SSL_PINNING_ENABLED) {
+                conf.setAlsoTrustPublicPki((Boolean) getValue(Config.TRUSTED_PUBLIC_PKI, jsonObject, Boolean.FALSE));
+                continue;
+            }
+
             Object value = getValue(attr, jsonObject);
             if (value != null) {
                 conf.putProperty(attr.key, value);

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationProvider.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/ConfigurationProvider.java
@@ -90,6 +90,13 @@ public interface ConfigurationProvider extends TrustedCertificateConfiguration, 
      */
     String getPrefix();
 
+    /**
+     * Based on the provided configuration the SDK, retrieve the ssl_pinning_enabled attribute.
+     *
+     * @return the ssl pinning enabled flag configured for the Gateway.
+     */
+    boolean isSSLPinningAllowed();
+
     // Configuration properties that are not currently documented as part of the public API.
 
     /**

--- a/mas-foundation/src/main/java/com/ca/mas/core/conf/DefaultConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/conf/DefaultConfiguration.java
@@ -64,6 +64,7 @@ public class DefaultConfiguration implements ConfigurationProvider {
 
     private List<X509Certificate> trustedCertificateAnchors = new ArrayList<X509Certificate>();
     private boolean alsoTrustPublicPki = true;
+    private boolean allowSSLPinning = true;
     private Set<PublicKeyHash> trustedCertificatePinnedPublicKeyHashes = new HashSet<PublicKeyHash>();
 
     /**
@@ -119,6 +120,10 @@ public class DefaultConfiguration implements ConfigurationProvider {
      */
     public void setAlsoTrustPublicPki(boolean alsoTrustPublicPki) {
         this.alsoTrustPublicPki = alsoTrustPublicPki;
+    }
+
+    public void setAllowSSLPinning(boolean allowSSLPinning) {
+        this.allowSSLPinning = allowSSLPinning;
     }
 
     /**
@@ -271,6 +276,9 @@ public class DefaultConfiguration implements ConfigurationProvider {
     public boolean isAlsoTrustPublicPki() {
         return alsoTrustPublicPki;
     }
+
+    @Override
+    public boolean isSSLPinningAllowed() { return allowSSLPinning; }
 
     @Override
     public Collection<PublicKeyHash> getTrustedCertificatePinnedPublicKeyHashes() {

--- a/mas-foundation/src/main/java/com/ca/mas/core/io/http/TrustedCertificateConfigurationTrustManager.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/io/http/TrustedCertificateConfigurationTrustManager.java
@@ -9,7 +9,6 @@ package com.ca.mas.core.io.http;
 
 import com.ca.mas.core.cert.PublicKeyHash;
 import com.ca.mas.core.cert.TrustedCertificateConfiguration;
-import com.ca.mas.foundation.MAS;
 import com.ca.mas.foundation.MASSecurityConfiguration;
 
 import java.io.IOException;
@@ -118,43 +117,39 @@ public class TrustedCertificateConfigurationTrustManager implements X509TrustMan
         List<Certificate> certs = config.getCertificates();
         List<String> hashes = config.getPublicKeyHashes();
 
-        if(MAS.isSslPinningEnabled() && config.isSslPinningEnabled())
-        {
-            //If we don't trust the public PKI, we fail the validation
-            if (config.trustPublicPki()) {
-                //All public PKI delegates must succeed
-                for (X509TrustManager delegate : publicPkiDelegates) {
-                    delegate.checkServerTrusted(chain, s);
-                }
-            }
-
-            //Check the private trust store for any thrown exceptions
-            if (certs != null && !certs.isEmpty()) {
-                checkPrivateTrustStoreDelegates(chain, s);
-            }
-
-            //Check the public key hashes
-            boolean hashesValid = false;
-            if (hashes != null) {
-                if (!hashes.isEmpty()) {
-                    for (X509Certificate xcert : chain) {
-                        PublicKey key = xcert.getPublicKey();
-                        if (key != null) {
-                            String hashString = PublicKeyHash.fromPublicKey(key).getHashString();
-                            if (hashes.contains(hashString)) {
-                                hashesValid = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if (!hashesValid) {
-                    throw new CertificateException("Server certificate chain did not contain any of the pinned public keys.");
-                }
+        //If we don't trust the public PKI, we fail the validation
+        if (config.trustPublicPki()) {
+            //All public PKI delegates must succeed
+            for (X509TrustManager delegate : publicPkiDelegates) {
+                delegate.checkServerTrusted(chain, s);
             }
         }
 
+        //Check the private trust store for any thrown exceptions
+        if (certs != null && !certs.isEmpty()) {
+            checkPrivateTrustStoreDelegates(chain, s);
+        }
+
+        //Check the public key hashes
+        boolean hashesValid = false;
+        if (hashes != null) {
+            if (!hashes.isEmpty()) {
+                for (X509Certificate xcert : chain) {
+                    PublicKey key = xcert.getPublicKey();
+                    if (key != null) {
+                        String hashString = PublicKeyHash.fromPublicKey(key).getHashString();
+                        if (hashes.contains(hashString)) {
+                            hashesValid = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!hashesValid) {
+                throw new CertificateException("Server certificate chain did not contain any of the pinned public keys.");
+            }
+        }
     }
 
     @Override

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
@@ -560,8 +560,8 @@ public class MAS {
     /**
      * Enables the SSL Pinning.
      */
-    public static void enableSSLPinning(boolean enableSSLPinning) {
-        ConfigurationManager.getInstance().enableSslPinningEnabled(enableSSLPinning);
+    public static void setSSLPinningEnabled(boolean enable) {
+        ConfigurationManager.getInstance().setSSLPinningEnabled(enable);
     }
     /**
      *  Value of the boolean indicator which indicate if the id_token validation is active or not.

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
@@ -560,7 +560,7 @@ public class MAS {
     /**
      * Enables the SSL Pinning.
      */
-    public static void enableSslPinningEnabled(boolean enableSSLPinning) {
+    public static void enableSSLPinning(boolean enableSSLPinning) {
         ConfigurationManager.getInstance().enableSslPinningEnabled(enableSSLPinning);
     }
     /**
@@ -584,7 +584,7 @@ public class MAS {
      *
      * @return true if ssl pinning is enabled, false otherwise
      */
-    public static boolean isSslPinningEnabled() {
+    public static boolean isSSLPinningEnabled() {
         return ConfigurationManager.getInstance().isSslPinningEnabled();
     }
 

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
@@ -21,6 +21,7 @@ import android.util.Log;
 
 import com.ca.mas.core.EventDispatcher;
 import com.ca.mas.core.MAGResultReceiver;
+import com.ca.mas.core.MobileSsoConfig;
 import com.ca.mas.core.MobileSsoFactory;
 import com.ca.mas.core.client.ServerClient;
 import com.ca.mas.core.conf.ConfigurationManager;
@@ -557,6 +558,12 @@ public class MAS {
     }
 
     /**
+     * Enables the SSL Pinning.
+     */
+    public static void enableSslPinningEnabled(boolean enableSSLPinning) {
+        ConfigurationManager.getInstance().enableSslPinningEnabled(enableSSLPinning);
+    }
+    /**
      *  Value of the boolean indicator which indicate if the id_token validation is active or not.
      */
     public static boolean isIdTokenValidationEnabled(){
@@ -570,6 +577,15 @@ public class MAS {
      */
     public static boolean isPKCEEnabled() {
         return ConfigurationManager.getInstance().isPKCEEnabled();
+    }
+
+    /**
+     * Determines whether PKCE extension is enabled.
+     *
+     * @return true if ssl pinning is enabled, false otherwise
+     */
+    public static boolean isSslPinningEnabled() {
+        return ConfigurationManager.getInstance().isSslPinningEnabled();
     }
 
     /**

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MAS.java
@@ -21,7 +21,6 @@ import android.util.Log;
 
 import com.ca.mas.core.EventDispatcher;
 import com.ca.mas.core.MAGResultReceiver;
-import com.ca.mas.core.MobileSsoConfig;
 import com.ca.mas.core.MobileSsoFactory;
 import com.ca.mas.core.client.ServerClient;
 import com.ca.mas.core.conf.ConfigurationManager;
@@ -558,12 +557,6 @@ public class MAS {
     }
 
     /**
-     * Enables the SSL Pinning.
-     */
-    public static void enableSslPinningEnabled(boolean enableSSLPinning) {
-        ConfigurationManager.getInstance().enableSslPinningEnabled(enableSSLPinning);
-    }
-    /**
      *  Value of the boolean indicator which indicate if the id_token validation is active or not.
      */
     public static boolean isIdTokenValidationEnabled(){
@@ -577,15 +570,6 @@ public class MAS {
      */
     public static boolean isPKCEEnabled() {
         return ConfigurationManager.getInstance().isPKCEEnabled();
-    }
-
-    /**
-     * Determines whether PKCE extension is enabled.
-     *
-     * @return true if ssl pinning is enabled, false otherwise
-     */
-    public static boolean isSslPinningEnabled() {
-        return ConfigurationManager.getInstance().isSslPinningEnabled();
     }
 
     /**

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
@@ -252,12 +252,12 @@ public class MASConfiguration {
         return ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider().getProperty(MobileSsoConfig.PROP_SSO_ENABLED);
     }
 
-//    /**
-//     * Determines if the client's SSO is enabled or not. This value is read from JSON configuration, if there is no value defined in keychain.
-//     */
-//    public boolean isSslPinningEnabled() {
-//        return ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider().getProperty(MobileSsoConfig.PROP_SSL_PINNING_ENABLED);
-//    }
+    /**
+     * Determines if the SDK will perform SSL Pinning for an authentication challenge. This read only value is within the JSON configuration file..
+     */
+    public boolean isSslPinningEnabled() {
+        return ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider().getProperty(MobileSsoConfig.PROP_ALLOW_SSL_PINNING);
+    }
 
     /**
      * Retrieves an endpoint path fragment for a given endpoint key, the keys can be one of the following

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
@@ -84,9 +84,14 @@ public class MASConfiguration {
      */
     static MASSecurityConfiguration createPrimaryConfiguration(Uri uri) {
         ConfigurationProvider configurationProvider = ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider();
+//        MASSecurityConfiguration.Builder configBuilder = new MASSecurityConfiguration.Builder()
+//                .host(uri)
+//                .trustPublicPKI(configurationProvider.isAlsoTrustPublicPki());
+
         MASSecurityConfiguration.Builder configBuilder = new MASSecurityConfiguration.Builder()
                 .host(uri)
-                .trustPublicPKI(configurationProvider.isAlsoTrustPublicPki());
+                .trustPublicPKI(configurationProvider.isAlsoTrustPublicPki())
+                .allowSSLPinning(configurationProvider.isSSLPinningAllowed());
 
         //Add certificates, if any exist
         Collection<X509Certificate> certificates = configurationProvider.getTrustedCertificateAnchors();

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
@@ -84,9 +84,6 @@ public class MASConfiguration {
      */
     static MASSecurityConfiguration createPrimaryConfiguration(Uri uri) {
         ConfigurationProvider configurationProvider = ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider();
-//        MASSecurityConfiguration.Builder configBuilder = new MASSecurityConfiguration.Builder()
-//                .host(uri)
-//                .trustPublicPKI(configurationProvider.isAlsoTrustPublicPki());
 
         MASSecurityConfiguration.Builder configBuilder = new MASSecurityConfiguration.Builder()
                 .host(uri)

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
@@ -247,13 +247,6 @@ public class MASConfiguration {
         return ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider().getProperty(MobileSsoConfig.PROP_SSO_ENABLED);
     }
 
-//    /**
-//     * Determines if the client's SSO is enabled or not. This value is read from JSON configuration, if there is no value defined in keychain.
-//     */
-//    public boolean isSslPinningEnabled() {
-//        return ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider().getProperty(MobileSsoConfig.PROP_SSL_PINNING_ENABLED);
-//    }
-
     /**
      * Retrieves an endpoint path fragment for a given endpoint key, the keys can be one of the following
      * <ul>

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASConfiguration.java
@@ -247,6 +247,13 @@ public class MASConfiguration {
         return ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider().getProperty(MobileSsoConfig.PROP_SSO_ENABLED);
     }
 
+//    /**
+//     * Determines if the client's SSO is enabled or not. This value is read from JSON configuration, if there is no value defined in keychain.
+//     */
+//    public boolean isSslPinningEnabled() {
+//        return ConfigurationManager.getInstance().getConnectedGatewayConfigurationProvider().getProperty(MobileSsoConfig.PROP_SSL_PINNING_ENABLED);
+//    }
+
     /**
      * Retrieves an endpoint path fragment for a given endpoint key, the keys can be one of the following
      * <ul>

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASSecurityConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASSecurityConfiguration.java
@@ -23,12 +23,14 @@ public interface MASSecurityConfiguration {
     Uri getHost();
     boolean isPublic();
     boolean trustPublicPki();
+    boolean isSslPinningEnabled();
     List<Certificate> getCertificates();
     List<String> getPublicKeyHashes();
 
     class Builder {
 
         private boolean isPublic;
+        private boolean isSSLPinningEnabled = false;
         private boolean trustPublicPKI;
 
         private List<Certificate> certificates;
@@ -53,6 +55,16 @@ public interface MASSecurityConfiguration {
          */
         public Builder trustPublicPKI(boolean trust) {
             this.trustPublicPKI = trust;
+            return this;
+        }
+
+        /**
+         * Determines whether or not to enable ssl pinning to primary gateway.
+         * @param sslPinning to include or not
+         * @return the builder object
+         */
+        public Builder enableSSLPinning(boolean sslPinning) {
+            this.isSSLPinningEnabled = sslPinning;
             return this;
         }
 
@@ -104,7 +116,7 @@ public interface MASSecurityConfiguration {
             }
 
             // If trustPublicPKI is false and no pinning information is found, throw an exception.
-            if (!trustPublicPKI && publicKeyHashes == null && certificates == null) {
+            if (isSSLPinningEnabled && !trustPublicPKI && publicKeyHashes == null && certificates == null) {
                 throw new IllegalArgumentException("Missing pinning type, cannot establish SSL.");
             }
 
@@ -132,6 +144,11 @@ public interface MASSecurityConfiguration {
                 @Override
                 public boolean trustPublicPki() {
                     return trustPublicPKI;
+                }
+
+                @Override
+                public boolean isSslPinningEnabled() {
+                    return isSSLPinningEnabled;
                 }
             };
         }

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASSecurityConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASSecurityConfiguration.java
@@ -23,14 +23,12 @@ public interface MASSecurityConfiguration {
     Uri getHost();
     boolean isPublic();
     boolean trustPublicPki();
-    boolean isSslPinningEnabled();
     List<Certificate> getCertificates();
     List<String> getPublicKeyHashes();
 
     class Builder {
 
         private boolean isPublic;
-        private boolean isSSLPinningEnabled = false;
         private boolean trustPublicPKI;
 
         private List<Certificate> certificates;
@@ -55,16 +53,6 @@ public interface MASSecurityConfiguration {
          */
         public Builder trustPublicPKI(boolean trust) {
             this.trustPublicPKI = trust;
-            return this;
-        }
-
-        /**
-         * Determines whether or not to enable ssl pinning to primary gateway.
-         * @param sslPinning to include or not
-         * @return the builder object
-         */
-        public Builder enableSSLPinning(boolean sslPinning) {
-            this.isSSLPinningEnabled = sslPinning;
             return this;
         }
 
@@ -116,7 +104,7 @@ public interface MASSecurityConfiguration {
             }
 
             // If trustPublicPKI is false and no pinning information is found, throw an exception.
-            if (isSSLPinningEnabled && !trustPublicPKI && publicKeyHashes == null && certificates == null) {
+            if (!trustPublicPKI && publicKeyHashes == null && certificates == null) {
                 throw new IllegalArgumentException("Missing pinning type, cannot establish SSL.");
             }
 
@@ -144,11 +132,6 @@ public interface MASSecurityConfiguration {
                 @Override
                 public boolean trustPublicPki() {
                     return trustPublicPKI;
-                }
-
-                @Override
-                public boolean isSslPinningEnabled() {
-                    return isSSLPinningEnabled;
                 }
             };
         }

--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASSecurityConfiguration.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASSecurityConfiguration.java
@@ -23,14 +23,14 @@ public interface MASSecurityConfiguration {
     Uri getHost();
     boolean isPublic();
     boolean trustPublicPki();
-    boolean isSslPinningEnabled();
+    boolean allowSSLPinning();
     List<Certificate> getCertificates();
     List<String> getPublicKeyHashes();
 
     class Builder {
 
         private boolean isPublic;
-        private boolean isSSLPinningEnabled = false;
+        private boolean allowSSLPinning = true;
         private boolean trustPublicPKI;
 
         private List<Certificate> certificates;
@@ -63,8 +63,8 @@ public interface MASSecurityConfiguration {
          * @param sslPinning to include or not
          * @return the builder object
          */
-        public Builder enableSSLPinning(boolean sslPinning) {
-            this.isSSLPinningEnabled = sslPinning;
+        public Builder allowSSLPinning(boolean sslPinning) {
+            this.allowSSLPinning = sslPinning;
             return this;
         }
 
@@ -116,7 +116,7 @@ public interface MASSecurityConfiguration {
             }
 
             // If trustPublicPKI is false and no pinning information is found, throw an exception.
-            if (isSSLPinningEnabled && !trustPublicPKI && publicKeyHashes == null && certificates == null) {
+            if (allowSSLPinning && !trustPublicPKI && publicKeyHashes == null && certificates == null) {
                 throw new IllegalArgumentException("Missing pinning type, cannot establish SSL.");
             }
 
@@ -147,8 +147,8 @@ public interface MASSecurityConfiguration {
                 }
 
                 @Override
-                public boolean isSslPinningEnabled() {
-                    return isSSLPinningEnabled;
+                public boolean allowSSLPinning() {
+                    return allowSSLPinning;
                 }
             };
         }


### PR DESCRIPTION
This is basically for SSL Pinning implemenation where we focussed below scenarios:

SSL Pinning will be disabled by default.
It can be enabled using the msso_config. The key for this: ssl_pinning_enabled
We can enable the ssl pinning using enableSSLPinning(boolean).