### PR TITLE
[DE485106] While writing the outstream, again boundary was getting as…

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/foundation/MASRequestBody.java
+++ b/mas-foundation/src/main/java/com/ca/mas/foundation/MASRequestBody.java
@@ -375,7 +375,7 @@ public abstract class MASRequestBody {
 
                 @Override
                 public long getContentLength() {
-                    return content.length + multipart_separator.length();
+                    return content.length;
                 }
 
                 @Override
@@ -397,8 +397,7 @@ public abstract class MASRequestBody {
                             progressListener.onProgress("" + (int) ((progress * 100) / content.length)); // sending progress percent to publishProgress
                         }
                     }
-                    outputStream.write((multipart_separator).getBytes());
-                    outputStream.flush();
+
                     if (progressListener != null) {
                         progressListener.onComplete();
                     }


### PR DESCRIPTION
…signed. Due to that duplicate boundary is getting added in the request while sending multipart data.