### PR TITLE
Storing the code verifier using shared preference to make it persistent

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/oauth/CodeVerifierCache.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/oauth/CodeVerifierCache.java
@@ -8,17 +8,18 @@
 
 package com.ca.mas.core.oauth;
 
+import com.ca.mas.core.storage.sharedstorage.SharedPreferencesUtil;
+
 /**
  * Temporary cache to store code verifier
  */
 public class CodeVerifierCache {
 
     private static CodeVerifierCache instance = new CodeVerifierCache();
-
-    private String state;
-    private String codeVerifier;
+    private SharedPreferencesUtil prefUtil = null;
 
     private CodeVerifierCache() {
+        prefUtil = new SharedPreferencesUtil("codeverifier");
     }
 
     public static CodeVerifierCache getInstance() {
@@ -26,26 +27,26 @@ public class CodeVerifierCache {
     }
 
     public void store(String state, String codeVerifier) {
-        this.state = state;
-        this.codeVerifier = codeVerifier;
+        prefUtil.save("state", state);
+        prefUtil.save("code", codeVerifier);
     }
 
     public String take(String state) {
-        if (this.state == null && state != null
-                || this.state != null && !this.state.equals(state)) {
+        if (prefUtil.getString("state") == null && state != null
+                || prefUtil.getString("state")!= null && !prefUtil.getString("state").equals(state)) {
             throw new IllegalStateException("OAuth State Mismatch");
         }
-        String cv = this.codeVerifier;
-        this.state = null;
-        this.codeVerifier = null;
+        String cv = prefUtil.getString("code");
+        prefUtil.delete("state");
+        prefUtil.delete("code");
         return cv;
     }
 
     //Workaround for pre MAG 3.3, Defect reference DE256594
     public String take() {
-        String cv = this.codeVerifier;
-        this.state = null;
-        this.codeVerifier = null;
+        String cv = prefUtil.getString("code");
+        prefUtil.delete("state");
+        prefUtil.delete("code");
         return cv;
     }
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import static com.ca.mas.foundation.MAS.TAG;
 import static com.ca.mas.foundation.MAS.getContext;
@@ -39,6 +40,7 @@ public class AccountManagerUtil implements StorageActions {
 
         // Gets the account type from the manifest
         String accountType = getAccountType(context);
+        StringBuilder sb = new StringBuilder("Account Details::Account type from Manifest "+accountType);
         if (accountType == null || accountType.isEmpty()) {
             throw new IllegalArgumentException(MASFoundationStrings.SHARED_STORAGE_NULL_ACCOUNT_TYPE);
         }
@@ -51,6 +53,7 @@ public class AccountManagerUtil implements StorageActions {
             mAccountManager = AccountManager.get(MAS.getContext());
             //Attempt to retrieve the account
             Account[] accounts = mAccountManager.getAccountsByType(accountType);
+            sb.append("No of accounts:: "+accounts.length);
             for (Account account : accounts) {
                 if (accountName != null &&accountName.equals(account.name)) {
                     String password = mAccountManager.getPassword(account);
@@ -69,11 +72,16 @@ public class AccountManagerUtil implements StorageActions {
 
             //Create the account if it wasn't retrieved,
             if (mAccount == null) {
+                sb.append("Account Name:: "+accountName);
+                sb.append("Account Type:: "+accountName);
                 mAccount = new Account(accountName, accountType);
-                mAccountManager.addAccountExplicitly(mAccount, identifier.toString(), null);
+                boolean accountCreated = mAccountManager.addAccountExplicitly(mAccount, identifier.toString(), null);
+                sb.append("Added account status "+accountCreated);
             }
+            sb.append("Getting account details after addition:: Name:: "+mAccount.name+
+                    " Type::" +mAccount.type+" hashcode::  "+mAccount.hashCode());
         } catch (Exception e) {
-            throw new MASSharedStorageException(e.getMessage(), e);
+            throw new MASSharedStorageException(e.getMessage()+" "+sb, e);
         }
     }
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -61,7 +61,10 @@ public class AccountManagerUtil implements StorageActions {
                         // - case migration from old AccountManagerStoreDataSource
                         mAccount = null;
                         identifier = new SharedStorageIdentifier();
+                        new NullPointerException("Password is null");
                     }
+                } else {
+                    new NullPointerException("Account Name does not exist");
                 }
             }
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -73,7 +73,7 @@ public class AccountManagerUtil implements StorageActions {
             //Create the account if it wasn't retrieved,
             if (mAccount == null) {
                 sb.append("Account Name:: "+accountName);
-                sb.append("Account Type:: "+accountName);
+                sb.append("Account Type:: "+accountType);
                 mAccount = new Account(accountName, accountType);
                 boolean accountCreated = mAccountManager.addAccountExplicitly(mAccount, identifier.toString(), null);
                 sb.append("Added account status "+accountCreated);

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -56,12 +56,13 @@ public class AccountManagerUtil implements StorageActions {
             SharedStorageIdentifier identifier = new SharedStorageIdentifier();
 
             mAccountManager = AccountManager.get(MAS.getContext());
-            //Attempt to retrieve the account
-            Account[] accounts = mAccountManager.getAccountsByType(accountType);
-            messageBuilder.append(" existing accounts (" + accountType + ")=" + accounts.length);
-            for (Account account : accounts) {
-                messageBuilder.append(" trying account:" + account.name);
-                synchronized (this) {
+            synchronized (mutex) {
+                //Attempt to retrieve the account
+                Account[] accounts = mAccountManager.getAccountsByType(accountType);
+                messageBuilder.append(" existing accounts (" + accountType + ")=" + accounts.length);
+                for (Account account : accounts) {
+                    messageBuilder.append(" trying account:" + account.name);
+
                     if (accountName.equals(account.name)) {
                         String password = mAccountManager.getPassword(account);
                         String savedPassword = identifier.toString();
@@ -76,10 +77,7 @@ public class AccountManagerUtil implements StorageActions {
                     }
                 }
 
-            }
-
-            //Create the account if it wasn't retrieved,
-            synchronized (this) {
+                //Create the account if it wasn't retrieved,
                 if (mAccount == null) {
                     messageBuilder.append(" account identifier when mAccount is null:" +identifier);
                     messageBuilder.append(" attempt to create an account explicitly name=" + accountName + ", accountType=" + accountType);
@@ -88,7 +86,6 @@ public class AccountManagerUtil implements StorageActions {
                     messageBuilder.append("created account status=" + accountCreated);
                 }
             }
-
             Log.e(TAG, "Retrieved account details name="+mAccount.name+
                     " type=" +mAccount.type+" hashcode=" + mAccount.hashCode());
         } catch (Exception e) {

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -60,6 +60,7 @@ public class AccountManagerUtil implements StorageActions {
             Account[] accounts = mAccountManager.getAccountsByType(accountType);
             messageBuilder.append(" existing accounts (" + accountType + ")=" + accounts.length);
             for (Account account : accounts) {
+                messageBuilder.append(" trying account:" + account.name);
                 if (accountName.equals(account.name)) {
                     String password = mAccountManager.getPassword(account);
                     String savedPassword = identifier.toString();

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -69,6 +69,7 @@ public class AccountManagerUtil implements StorageActions {
                     }else {
                         // - case migration from old AccountManagerStoreDataSource
                         mAccount = null;
+                        messageBuilder.append(" password is null or password not equals to saved password:");
                         identifier = new SharedStorageIdentifier();
                     }
                 }
@@ -76,6 +77,7 @@ public class AccountManagerUtil implements StorageActions {
 
             //Create the account if it wasn't retrieved,
             if (mAccount == null) {
+                messageBuilder.append(" account identifier when mAccount is null:" +identifier);
                 messageBuilder.append(" attempt to create an account explicitly name=" + accountName + ", accountType=" + accountType);
                 mAccount = new Account(accountName, accountType);
                 boolean accountCreated = mAccountManager.addAccountExplicitly(mAccount, identifier.toString(), null);

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -53,10 +53,11 @@ public class AccountManagerUtil implements StorageActions {
         shared = sharedStorage;
 
         try {
-            SharedStorageIdentifier identifier = new SharedStorageIdentifier();
-
-            mAccountManager = AccountManager.get(MAS.getContext());
             synchronized (mutex) {
+                SharedStorageIdentifier identifier = new SharedStorageIdentifier();
+
+                mAccountManager = AccountManager.get(MAS.getContext());
+
                 //Attempt to retrieve the account
                 Account[] accounts = mAccountManager.getAccountsByType(accountType);
                 messageBuilder.append(" existing accounts (" + accountType + ")=" + accounts.length);

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -61,10 +61,9 @@ public class AccountManagerUtil implements StorageActions {
                         // - case migration from old AccountManagerStoreDataSource
                         mAccount = null;
                         identifier = new SharedStorageIdentifier();
-                        new NullPointerException("Password is null");
                     }
                 } else {
-                    new NullPointerException("Account Name does not exist");
+                    throw new IllegalArgumentException("Invalid parameters, Account name cannot be null");
                 }
             }
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -52,10 +52,10 @@ public class AccountManagerUtil implements StorageActions {
             //Attempt to retrieve the account
             Account[] accounts = mAccountManager.getAccountsByType(accountType);
             for (Account account : accounts) {
-                if (accountName.equals(account.name)) {
+                if (accountName != null &&accountName.equals(account.name)) {
                     String password = mAccountManager.getPassword(account);
                     String savedPassword = identifier.toString();
-                    if (password.equals(savedPassword)) {
+                    if (password != null && password.equals(savedPassword)) {
                         mAccount = account;
                     }else {
                         // - case migration from old AccountManagerStoreDataSource


### PR DESCRIPTION
**Issue**:
Presently Code verifier is getting generated and stored in Memory cache. When mobile app which is built using SDK calls another external app for authentication, it goes to background. In some cases, it is getting killed by the OS. Due to this, code verifier, which is stored in memory cache is getting lost.

**Fix**:
SDK has a support for Shared Preference which is persistent local database for Android. Implemented the shared preference and storing the code verifier and the state. This will ensure that the values will be present although app is in background or getting killed by any chance.