### PR TITLE
Tls 1.3 support with encryption no padding develop backport

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/io/ssl/TLSSocketFactory.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/io/ssl/TLSSocketFactory.java
@@ -7,6 +7,8 @@
 
 package com.ca.mas.core.io.ssl;
 
+import android.os.Build;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -21,7 +23,9 @@ class TLSSocketFactory extends SSLSocketFactory {
     private static final String SSL_TLS_V1_PROTOCOL = "TLSv1";
     private static final String SSL_TLS_V1_1_PROTOCOL = "TLSv1.1";
     private static final String SSL_TLS_V1_2_PROTOCOL = "TLSv1.2";
+    private static final String SSL_TLS_V1_3_PROTOCOL = "TLSv1.3";
     private static final String[] SUPPORTED_TLS =  {SSL_V3_PROTOCOL, SSL_TLS_V1_PROTOCOL, SSL_TLS_V1_1_PROTOCOL, SSL_TLS_V1_2_PROTOCOL};
+    private static final String[] SUPPORTED_TLS_FROM_ANDROID_Q =  {SSL_V3_PROTOCOL, SSL_TLS_V1_PROTOCOL, SSL_TLS_V1_1_PROTOCOL, SSL_TLS_V1_2_PROTOCOL, SSL_TLS_V1_3_PROTOCOL};
 
     TLSSocketFactory(SSLSocketFactory sslSocketFactory) {
         this.sslSocketFactory = sslSocketFactory;
@@ -68,8 +72,14 @@ class TLSSocketFactory extends SSLSocketFactory {
     }
 
     private Socket enableTLS(Socket socket) {
-        if (socket != null && (socket instanceof SSLSocket)) {
-            ((SSLSocket) socket).setEnabledProtocols(SUPPORTED_TLS);
+        if ((socket instanceof SSLSocket)) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                ((SSLSocket) socket).setEnabledProtocols(SUPPORTED_TLS);
+            }
+            else
+            {
+                ((SSLSocket) socket).setEnabledProtocols(SUPPORTED_TLS_FROM_ANDROID_Q);
+            }
         }
         return socket;
     }

--- a/mas-foundation/src/main/java/com/ca/mas/core/security/AndroidMKeyRepository.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/security/AndroidMKeyRepository.java
@@ -29,6 +29,7 @@ import static android.security.keystore.KeyProperties.DIGEST_SHA1;
 import static android.security.keystore.KeyProperties.DIGEST_SHA256;
 import static android.security.keystore.KeyProperties.DIGEST_SHA384;
 import static android.security.keystore.KeyProperties.DIGEST_SHA512;
+import static android.security.keystore.KeyProperties.ENCRYPTION_PADDING_NONE;
 import static android.security.keystore.KeyProperties.ENCRYPTION_PADDING_PKCS7;
 import static android.security.keystore.KeyProperties.ENCRYPTION_PADDING_RSA_OAEP;
 import static android.security.keystore.KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1;
@@ -59,7 +60,7 @@ public class AndroidMKeyRepository extends AndroidKeyStoreRepository {
                 .setRandomizedEncryptionRequired(false)
                 .setBlockModes(BLOCK_MODE_CBC, BLOCK_MODE_CTR, BLOCK_MODE_ECB, BLOCK_MODE_GCM)
                 .setDigests(DIGEST_NONE, DIGEST_MD5, DIGEST_SHA1, DIGEST_SHA256, DIGEST_SHA384, DIGEST_SHA512)
-                .setEncryptionPaddings(ENCRYPTION_PADDING_PKCS7, ENCRYPTION_PADDING_RSA_OAEP, ENCRYPTION_PADDING_RSA_PKCS1)
+                .setEncryptionPaddings(ENCRYPTION_PADDING_PKCS7, ENCRYPTION_PADDING_RSA_OAEP, ENCRYPTION_PADDING_RSA_PKCS1, ENCRYPTION_PADDING_NONE)
                 .setSignaturePaddings(SIGNATURE_PADDING_RSA_PSS, SIGNATURE_PADDING_RSA_PKCS1);
     }
 


### PR DESCRIPTION
**This is the backporting to develop branch.**
**Issue**: After Gateway 10 CR03, RSA-PSS support has been added in the Gateway but for Android 10 and above, we have missed it in our SDK. We need to enable ENCRYPTION_PADDING_NONE to support the same for Android 10 and above.

Apart from that, Android SDK 29 and above has started supporting TLS 1.3. As our gateway has the support for TLS 1.3, MAS SDK does not have that. So we enhanced it to support the TLS 1.3 protocol.

For the devices which are running below Android SDK 29(means Android 9 or below devices), they don't support TLS 1.3. In that case, we should enable TLS 1.2 and TLS 1.3 both on the gateway.