### PR TITLE
Codeverifier cache change and Account Manager Util changes for Achmea Base Branch

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/storage/sharedstorage/AccountManagerUtil.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import static com.ca.mas.foundation.MAS.TAG;
 import static com.ca.mas.foundation.MAS.getContext;
@@ -35,45 +36,58 @@ public class AccountManagerUtil implements StorageActions {
 
     private Account mAccount;
 
-    public AccountManagerUtil(Context context, String accountName, boolean sharedStorage){
+    public AccountManagerUtil(Context context, String accountName, boolean sharedStorage) {
 
         // Gets the account type from the manifest
-        String accountType = getAccountType(context);
+        final String accountType = getAccountType(context);
+        final StringBuilder messageBuilder = new StringBuilder();
+
         if (accountType == null || accountType.isEmpty()) {
             throw new IllegalArgumentException(MASFoundationStrings.SHARED_STORAGE_NULL_ACCOUNT_TYPE);
         }
 
+        if (accountName == null) {
+            throw new IllegalArgumentException(MASFoundationStrings.SHARED_STORAGE_NULL_ACCOUNT_NAME);
+        }
+
         shared = sharedStorage;
 
-        try {
-            SharedStorageIdentifier identifier = new SharedStorageIdentifier();
+        synchronized (mutex) {
+            try {
+                SharedStorageIdentifier identifier = new SharedStorageIdentifier();
 
-            mAccountManager = AccountManager.get(MAS.getContext());
-            //Attempt to retrieve the account
-            Account[] accounts = mAccountManager.getAccountsByType(accountType);
-            for (Account account : accounts) {
-                if (accountName.equals(account.name)) {
-                    String password = mAccountManager.getPassword(account);
-                    String savedPassword = identifier.toString();
-                    if (password.equals(savedPassword)) {
-                        mAccount = account;
-                    }else {
-                        // - case migration from old AccountManagerStoreDataSource
-                        mAccount = null;
-                        identifier = new SharedStorageIdentifier();
+                mAccountManager = AccountManager.get(MAS.getContext());
+                //Attempt to retrieve the account
+                Account[] accounts = mAccountManager.getAccountsByType(accountType);
+                messageBuilder.append(" existing accounts =").append(accounts.length);
+                for (Account account : accounts) {
+                    if (accountName.equals(account.name)) {
+                        String password = mAccountManager.getPassword(account);
+                        String savedPassword = identifier.toString();
+                        if (password != null && password.equals(savedPassword)) {
+                            mAccount = account;
+                        } else {
+                            // - case migration from old AccountManagerStoreDataSource
+                            mAccount = null;
+                            messageBuilder.append(" password is null or password not equals to saved password:");
+                            identifier = new SharedStorageIdentifier();
+                        }
                     }
                 }
-            }
 
-            //Create the account if it wasn't retrieved,
-            if (mAccount == null) {
-                mAccount = new Account(accountName, accountType);
-                mAccountManager.addAccountExplicitly(mAccount, identifier.toString(), null);
+                //Create the account if it wasn't retrieved,
+                if (mAccount == null) {
+                    mAccount = new Account(accountName, accountType);
+                    boolean accountCreated = mAccountManager.addAccountExplicitly(mAccount, identifier.toString(), null);
+                    messageBuilder.append("created account status=").append(accountCreated);
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to retrieve account, " + e.getMessage() + " - " + messageBuilder.toString());
+                throw new MASSharedStorageException(e.getMessage() + " - " + messageBuilder.toString(), e);
             }
-        } catch (Exception e) {
-            throw new MASSharedStorageException(e.getMessage(), e);
         }
     }
+
 
     // Parses the account type for MASAuthenticatorService from the authenticator xml file
     // specified in the application's AndroidManifest.xml.


### PR DESCRIPTION
Issue:
Presently Code verifier is getting generated and stored in Memory cache. When mobile app which is built using SDK calls another external app for authentication, it goes to background. In some cases, it is getting killed by the OS. Due to this, code verifier, which is stored in memory cache is getting lost.

Fix:
SDK has a support for Shared Preference which is persistent local database for Android. Implemented the shared preference and storing the code verifier and the state. This will ensure that the values will be present although app is in background or getting killed by any chance.

We are adding a check for Null Pointer Exception for the Password and Account Name field while creating the account