### PR TITLE
Handling the 500 server error while getting access token using refresh token and preventing user logout

### DIFF
--- a/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
@@ -81,7 +81,7 @@ public class MssoContext {
 
     private String deviceName;
 
-    private boolean skipIdtokenValidation;
+    private boolean skipTokenRenewal;
 
     private volatile MAGHttpClient magHttpClient;
 
@@ -606,12 +606,12 @@ public class MssoContext {
         return clientExpiration != 0 && clientExpiration < new Date().getTime() / 1000;
     }
 
-    public void setSkipObtainAccessTokenUsingIdToken(boolean skipToken) {
-        this.skipIdtokenValidation = skipToken;
+    public void setFailTokenRenewalOnServerErrors(boolean skipToken) {
+        this.skipTokenRenewal = skipToken;
     }
 
-    public boolean getSkipObtainAccessTokenUsingIdToken(){
-        return skipIdtokenValidation;
+    public boolean getFailTokenRenewalOnServerErrors(){
+        return skipTokenRenewal;
     }
 
 }

--- a/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
@@ -606,11 +606,11 @@ public class MssoContext {
         return clientExpiration != 0 && clientExpiration < new Date().getTime() / 1000;
     }
 
-    public void setFailTokenRenewalOnServerErrors(boolean skipToken) {
+    public void setDonotLogoutTokenRenewalOnServerError(boolean skipToken) {
         this.skipTokenRenewal = skipToken;
     }
 
-    public boolean getFailTokenRenewalOnServerErrors(){
+    public boolean getDonotLogoutTokenRenewalOnServerErrors(){
         return skipTokenRenewal;
     }
 

--- a/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/context/MssoContext.java
@@ -81,6 +81,8 @@ public class MssoContext {
 
     private String deviceName;
 
+    private boolean skipIdtokenValidation;
+
     private volatile MAGHttpClient magHttpClient;
 
     private volatile MASAuthCredentials credentials;
@@ -602,6 +604,14 @@ public class MssoContext {
 
     public boolean isClientCredentialExpired(Long clientExpiration) {
         return clientExpiration != 0 && clientExpiration < new Date().getTime() / 1000;
+    }
+
+    public void setSkipObtainAccessTokenUsingIdToken(boolean skipToken) {
+        this.skipIdtokenValidation = skipToken;
+    }
+
+    public boolean getSkipObtainAccessTokenUsingIdToken(){
+        return skipIdtokenValidation;
     }
 
 }

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
@@ -261,7 +261,7 @@ class AccessTokenAssertion implements MssoAssertion {
             if(mssoContext.getFailTokenRenewalOnServerErrors() && tse.getStatus() == 500 && mssoContext.getIdToken() != null) {
                 String deviceIdentifier = mssoContext.getTokenManager().getMagIdentifier();
                 if (JWTValidation.validateIdToken(mssoContext,mssoContext.getIdToken(), deviceIdentifier, clientId, clientSecret)) {
-                    throwInternalServerException(tse);
+                    throw tse;
                 }
             }
 
@@ -293,10 +293,5 @@ class AccessTokenAssertion implements MssoAssertion {
                 //Ignore the Exception
         }
     }
-
-    private void throwInternalServerException(OAuthServerException e) throws OAuthServerException {
-        if (e.getStatus() == 500) {
-            throw e;
-        }
-    }
+    
 }

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
@@ -258,7 +258,7 @@ class AccessTokenAssertion implements MssoAssertion {
 
             rethrowOrIgnore(tse);
 
-            if(mssoContext.getFailTokenRenewalOnServerErrors() && tse.getStatus() == 500 && mssoContext.getIdToken() != null) {
+            if(mssoContext.getDonotLogoutTokenRenewalOnServerErrors() && tse.getStatus() == 500 && mssoContext.getIdToken() != null) {
                 String deviceIdentifier = mssoContext.getTokenManager().getMagIdentifier();
                 if (JWTValidation.validateIdToken(mssoContext,mssoContext.getIdToken(), deviceIdentifier, clientId, clientSecret)) {
                     throw tse;
@@ -293,5 +293,5 @@ class AccessTokenAssertion implements MssoAssertion {
                 //Ignore the Exception
         }
     }
-    
+
 }

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
@@ -258,8 +258,7 @@ class AccessTokenAssertion implements MssoAssertion {
 
             rethrowOrIgnore(tse);
 
-            if(!mssoContext.getSkipObtainAccessTokenUsingIdToken() && tse.getStatus() == 500 && mssoContext.getIdToken() != null)
-            {
+            if(mssoContext.getFailTokenRenewalOnServerErrors() && tse.getStatus() == 500 && mssoContext.getIdToken() != null) {
                 String deviceIdentifier = mssoContext.getTokenManager().getMagIdentifier();
                 if (JWTValidation.validateIdToken(mssoContext,mssoContext.getIdToken(), deviceIdentifier, clientId, clientSecret)) {
                     throwInternalServerException(tse);

--- a/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
+++ b/mas-foundation/src/main/java/com/ca/mas/core/policy/AccessTokenAssertion.java
@@ -256,15 +256,15 @@ class AccessTokenAssertion implements MssoAssertion {
 
         } catch (OAuthServerException tse) {
 
+            rethrowOrIgnore(tse);
 
-            if(tse.getStatus() == 500 && mssoContext.getIdToken() != null)
+            if(!mssoContext.getSkipObtainAccessTokenUsingIdToken() && tse.getStatus() == 500 && mssoContext.getIdToken() != null)
             {
                 String deviceIdentifier = mssoContext.getTokenManager().getMagIdentifier();
                 if (JWTValidation.validateIdToken(mssoContext,mssoContext.getIdToken(), deviceIdentifier, clientId, clientSecret)) {
                     throwInternalServerException(tse);
                 }
             }
-            rethrowOrIgnore(tse);
 
             if(tse.getResponse()!= null){
                 //The access token and refresh token are no longer valid.


### PR DESCRIPTION
**Issue**: During DB Maintenance, if access token is expired, SDK will try to get the access token using refresh token. But as server is down, it will return 500 error code. Also MAS SDK, logout the user as it falls back to get the access token using ID token. 

**Solution** : During obtain the access token using refresh token, we are checking if server is giving 500 error code. Based on that, we are throwing the exception and not falling back to get the access token using ID token. Also, we are not clearing the tokens.